### PR TITLE
"Heavy" push

### DIFF
--- a/src/dorsal/file/dorsal_file.py
+++ b/src/dorsal/file/dorsal_file.py
@@ -1607,6 +1607,103 @@ class LocalFile(_DorsalFile):
         )
         return validation_result
 
+    def _push_heavy(
+        self, public: bool = False, api_key: str | None = None, strict: bool = False
+    ) -> "FileIndexResponse":
+        """
+        When file record exceeds the 15MiB limit (due to large annotations), this method pushes it in two phases:
+
+        1. Strips the large annotations from the file record and pushes the record, without non-core annotations
+
+        2. Pushes the large annotations via `add_file_annotation`
+
+        """
+        from dorsal.common.exceptions import PartialIndexingError
+
+        assert self._client is not None, "DorsalClient must be initialized before pushing."
+        assert self.hash is not None, "File hash must be computed before pushing."
+
+        client = self._client
+        file_hash = self.hash
+
+        logger.info("Payload exceeds 14 MiB threshold. Farming out to _push_heavy...")
+
+        lite_record = self.model.model_copy(deep=True)
+        extracted_annotations = {}
+
+        if lite_record.annotations is not None:
+
+            def extract(dataset_id, item_or_list):
+                if item_or_list is None:
+                    return None
+
+                if dataset_id not in extracted_annotations:
+                    extracted_annotations[dataset_id] = []
+
+                items = item_or_list if isinstance(item_or_list, list) else [item_or_list]
+                extracted_annotations[dataset_id].extend(items)
+
+                return None
+
+            extra = getattr(lite_record.annotations, "__pydantic_extra__", None)
+            if extra is not None:  # Explicitly check for None
+                for field, val in list(extra.items()):
+                    extract(field, val)
+                    del extra[field]
+
+        try:
+            if public:
+                response = client.index_public_file_records(file_records=[lite_record], api_key=api_key)
+            else:
+                response = client.index_private_file_records(file_records=[lite_record], api_key=api_key)
+        except DorsalClientError as err:
+            logger.error("Failed to push lite file record for '%s'. Error: %s", self._file_path, err)
+            raise
+
+        failed_details = []
+
+        for dataset_id, items in extracted_annotations.items():
+            for item in items:
+                try:
+                    client.add_file_annotation(
+                        file_hash=file_hash, schema_id=dataset_id, annotation=item, overwrite=True, api_key=api_key
+                    )
+                    response.success += 1
+                    response.total += 1
+                except DorsalClientError as err:
+                    response.error += 1
+                    response.total += 1
+                    detail_str = f"Heavy Annotation Append '{dataset_id}': {err}"
+                    logger.warning("  > %s", detail_str)
+                    failed_details.append(detail_str)
+
+        if response.error > 0:
+            error_msg = f"PARTIAL FAILURE pushing file '{self._file_path}'. The base record was created, but {response.error} annotation(s) were rejected."
+            logger.warning(error_msg)
+
+            for result in response.results:
+                if result.annotations:
+                    for annotation in result.annotations:
+                        if annotation.status == "error":
+                            failed_details.append(f"Annotation '{annotation.name}': {annotation.detail}")
+                if result.tags:
+                    for result_tag in result.tags:
+                        if result_tag.status == "error":
+                            failed_details.append(f"Tag '{result_tag.name}': {result_tag.detail}")
+
+            if strict:
+                summary_data = {
+                    "total": response.total,
+                    "success": response.success,
+                    "error": response.error,
+                    "failures": failed_details,
+                }
+                raise PartialIndexingError(message=error_msg + " (Strict Mode enabled)", summary=summary_data)
+        else:
+            logger.info("Successfully pushed HEAVY file record for '%s' to DorsalHub.", self._file_path)
+
+        return response
+
     def push(self, public: bool = False, api_key: str | None = None, strict: bool = False) -> FileIndexResponse:
         """Indexes file's metadata (annotations and tags) to DorsalHub.
 
@@ -1655,6 +1752,10 @@ class LocalFile(_DorsalFile):
 
         if self._client is None:
             self._client = get_shared_dorsal_client(api_key=api_key)
+
+        record_bytes = self.model.model_dump_json(exclude_none=True).encode("utf-8")
+        if len(record_bytes) > (14 * 1024 * 1024):  # Server rejects at 15MiB giving 1MiB of headroom for core record
+            return self._push_heavy(public=public, api_key=api_key, strict=strict)
 
         client = self._client
 

--- a/tests/file/dorsal_file/test_localfile.py
+++ b/tests/file/dorsal_file/test_localfile.py
@@ -991,3 +991,85 @@ def test_add_url_invalid_format(mock_metadata_reader, mock_file_record_strict, f
 
     with pytest.raises(ValueError, match="Invalid URL data"):
         lf.add_url("not_a_valid_url")
+
+
+def test_local_file_push_triggers_heavy(mock_metadata_reader, mock_file_record_strict, fs, mocker):
+    """Test that push() delegates to _push_heavy when the 14 MiB threshold is crossed."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_client = MagicMock()
+    lf = LocalFile(file_path, client=mock_client)
+
+    mocker.patch.object(lf.model, "model_dump_json", return_value="a" * (15 * 1024 * 1024))
+
+    mock_push_heavy = mocker.patch.object(lf, "_push_heavy", return_value=MagicMock())
+
+    lf.push()
+
+    mock_push_heavy.assert_called_once()
+    mock_client.index_private_file_records.assert_not_called()
+
+
+def test_push_heavy_logic_success(mock_metadata_reader, mock_file_record_strict, fs):
+    """Test that _push_heavy correctly strips dynamic annotations and uploads them sequentially."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+
+    mock_ann_1 = MagicMock()
+    mock_ann_2 = MagicMock()
+    mock_file_record_strict.annotations.__pydantic_extra__ = {
+        "open/document-extraction": [mock_ann_1, mock_ann_2]
+    }
+    
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_client = MagicMock()
+    mock_response = FileIndexResponse(total=1, success=1, error=0, unauthorized=0, results=[])
+    mock_client.index_private_file_records.return_value = mock_response
+
+    lf = LocalFile(file_path, client=mock_client)
+    lf.hash = "a" * 64
+
+    response = lf._push_heavy(public=False)
+
+    mock_client.index_private_file_records.assert_called_once()
+    uploaded_lite_record = mock_client.index_private_file_records.call_args.kwargs["file_records"][0]
+
+    extra = getattr(uploaded_lite_record.annotations, "__pydantic_extra__", {}) or {}
+    assert "open/document-extraction" not in extra
+
+    assert mock_client.add_file_annotation.call_count == 2
+
+    assert response.total == 3
+    assert response.success == 3
+    assert response.error == 0
+
+
+def test_push_heavy_partial_failure_strict(mock_metadata_reader, mock_file_record_strict, fs):
+    """Test that _push_heavy raises a PartialIndexingError if an individual chunk fails in strict mode."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+
+    mock_ann_1 = MagicMock()
+    mock_file_record_strict.annotations.__pydantic_extra__ = {
+        "open/document-extraction": [mock_ann_1]
+    }
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_client = MagicMock()
+    mock_response = FileIndexResponse(total=1, success=1, error=0, unauthorized=0, results=[])
+    mock_client.index_private_file_records.return_value = mock_response
+
+    mock_client.add_file_annotation.side_effect = DorsalClientError("Payload chunk rejected")
+
+    lf = LocalFile(file_path, client=mock_client)
+    lf.hash = "a" * 64
+
+    with pytest.raises(PartialIndexingError) as exc_info:
+        lf._push_heavy(strict=True)
+        
+    assert "PARTIAL FAILURE" in str(exc_info.value)
+    assert mock_response.error == 1
+    assert mock_response.success == 1  # The base record still succeeded!

--- a/tests/file/dorsal_file/test_localfile.py
+++ b/tests/file/dorsal_file/test_localfile.py
@@ -1002,12 +1002,17 @@ def test_local_file_push_triggers_heavy(mock_metadata_reader, mock_file_record_s
     mock_client = MagicMock()
     lf = LocalFile(file_path, client=mock_client)
 
-    mocker.patch.object(lf.model, "model_dump_json", return_value="a" * (15 * 1024 * 1024))
+    # FIX: Patch the class-level method instead of the instance to avoid Pydantic __setattr__ blocks
+    from dorsal.file.validators.file_record import FileRecordStrict
 
+    mocker.patch.object(FileRecordStrict, "model_dump_json", return_value="a" * (15 * 1024 * 1024))
+
+    # Spy on or patch _push_heavy to intercept the call
     mock_push_heavy = mocker.patch.object(lf, "_push_heavy", return_value=MagicMock())
 
     lf.push()
 
+    # Verify delegation
     mock_push_heavy.assert_called_once()
     mock_client.index_private_file_records.assert_not_called()
 
@@ -1019,10 +1024,8 @@ def test_push_heavy_logic_success(mock_metadata_reader, mock_file_record_strict,
 
     mock_ann_1 = MagicMock()
     mock_ann_2 = MagicMock()
-    mock_file_record_strict.annotations.__pydantic_extra__ = {
-        "open/document-extraction": [mock_ann_1, mock_ann_2]
-    }
-    
+    mock_file_record_strict.annotations.__pydantic_extra__ = {"open/document-extraction": [mock_ann_1, mock_ann_2]}
+
     mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
 
     mock_client = MagicMock()
@@ -1053,9 +1056,7 @@ def test_push_heavy_partial_failure_strict(mock_metadata_reader, mock_file_recor
     fs.create_file(file_path)
 
     mock_ann_1 = MagicMock()
-    mock_file_record_strict.annotations.__pydantic_extra__ = {
-        "open/document-extraction": [mock_ann_1]
-    }
+    mock_file_record_strict.annotations.__pydantic_extra__ = {"open/document-extraction": [mock_ann_1]}
     mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
 
     mock_client = MagicMock()
@@ -1069,7 +1070,7 @@ def test_push_heavy_partial_failure_strict(mock_metadata_reader, mock_file_recor
 
     with pytest.raises(PartialIndexingError) as exc_info:
         lf._push_heavy(strict=True)
-        
+
     assert "PARTIAL FAILURE" in str(exc_info.value)
     assert mock_response.error == 1
     assert mock_response.success == 1  # The base record still succeeded!

--- a/tests/file/dorsal_file/test_localfile.py
+++ b/tests/file/dorsal_file/test_localfile.py
@@ -1073,4 +1073,114 @@ def test_push_heavy_partial_failure_strict(mock_metadata_reader, mock_file_recor
 
     assert "PARTIAL FAILURE" in str(exc_info.value)
     assert mock_response.error == 1
-    assert mock_response.success == 1  # The base record still succeeded!
+    assert mock_response.success == 1
+
+
+def test_push_heavy_extract_none_handling(mock_metadata_reader, mock_file_record_strict, fs):
+    """Covers the 'if item_or_list is None: return None' branch in _push_heavy's extract helper."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+
+    mock_file_record_strict.annotations.__pydantic_extra__ = {"open/document-extraction": None}
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.error = 0
+    mock_client.index_private_file_records.return_value = mock_response
+
+    lf = LocalFile(file_path, client=mock_client)
+    lf.hash = "a" * 64
+
+    lf._push_heavy(public=False)
+
+    mock_client.index_private_file_records.assert_called_once()
+    mock_client.add_file_annotation.assert_not_called()
+
+
+def test_push_heavy_public_and_client_exception(mock_metadata_reader, mock_file_record_strict, fs):
+    """Covers the public=True branch and the DorsalClientError exception block."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_client = MagicMock()
+    mock_client.index_public_file_records.side_effect = DorsalClientError("Network timeout")
+
+    lf = LocalFile(file_path, client=mock_client)
+    lf.hash = "a" * 64
+
+    with pytest.raises(DorsalClientError, match="Network timeout"):
+        lf._push_heavy(public=True, api_key="test_key")
+
+    mock_client.index_public_file_records.assert_called_once()
+    mock_client.index_private_file_records.assert_not_called()
+
+
+def test_push_heavy_error_details_iteration(mock_metadata_reader, mock_file_record_strict, fs):
+    """Covers the nested loops extracting specific annotation and tag errors from response.results."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    mock_ann_error = MagicMock()
+    mock_ann_error.status = "error"
+    mock_ann_error.name = "open/document-extraction"
+    mock_ann_error.detail = "Payload validation failed"
+
+    mock_tag_error = MagicMock()
+    mock_tag_error.status = "error"
+    mock_tag_error.name = "important_tag"
+    mock_tag_error.detail = "Invalid tag format"
+
+    mock_result_item = MagicMock()
+    mock_result_item.annotations = [mock_ann_error]
+    mock_result_item.tags = [mock_tag_error]
+
+    mock_response = MagicMock()
+    mock_response.error = 2
+    mock_response.total = 2
+    mock_response.success = 0
+    mock_response.results = [mock_result_item]
+
+    mock_client = MagicMock()
+    mock_client.index_private_file_records.return_value = mock_response
+
+    lf = LocalFile(file_path, client=mock_client)
+    lf.hash = "a" * 64
+
+    with pytest.raises(PartialIndexingError) as exc_info:
+        lf._push_heavy(strict=True)
+
+    failures = exc_info.value.summary["failures"]
+    assert "Annotation 'open/document-extraction': Payload validation failed" in failures
+    assert "Tag 'important_tag': Invalid tag format" in failures
+
+
+def test_local_file_push_initializes_client(mock_metadata_reader, mock_file_record_strict, fs, mocker):
+    """Covers the 'if self._client is None' lazy initialization in LocalFile.push()."""
+    file_path = "/fake.txt"
+    fs.create_file(file_path)
+    mock_metadata_reader._get_or_create_record.return_value = mock_file_record_strict
+
+    from dorsal.file.validators.file_record import FileRecordStrict
+
+    mocker.patch.object(FileRecordStrict, "model_dump_json", return_value="{}")
+
+    mock_get_client = mocker.patch("dorsal.file.dorsal_file.get_shared_dorsal_client")
+    mock_client_instance = MagicMock()
+
+    mock_response = MagicMock()
+    mock_response.error = 0
+    mock_client_instance.index_private_file_records.return_value = mock_response
+
+    mock_get_client.return_value = mock_client_instance
+
+    lf = LocalFile(file_path, client=None)
+    assert lf._client is None
+
+    lf.push(api_key="dynamic_test_key")
+
+    mock_get_client.assert_called_once_with(api_key="dynamic_test_key")
+    assert lf._client == mock_client_instance
+    mock_client_instance.index_private_file_records.assert_called_once()

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -39,7 +39,6 @@ def mock_runner():
         pipeline_result = MagicMock()
         pipeline_result.error = None
 
-        # Wrap the mocks in lists to match the new signature
         runner_instance.run_single_model.side_effect = [[base_result], [pipeline_result]]
 
         yield runner_instance
@@ -57,12 +56,10 @@ def test_test_model_success(mock_runner):
 def test_test_model_base_failure(mock_runner):
     failure = MagicMock()
     failure.error = "Base failed"
-    # Wrap in a list
     mock_runner.run_single_model.side_effect = [[failure]]
 
     result = run_model(DummyModel, "/tmp/fake.txt")
 
-    # Assert against the first item in the returned list
     assert result[0].error == "Base failed"
     assert mock_runner.run_single_model.call_count == 1
 
@@ -76,11 +73,9 @@ def test_test_model_dependency_check():
     base_result.error = None
     base_result.records = [{"name": "f.txt", "extension": ".txt", "media_type": "text/plain"}]
 
-    # Wrap side_effect in a list
     with patch.object(ModelRunner, "run_single_model", side_effect=[[base_result]]) as mock_run:
         result = run_model(DummyModel, "/f.txt", dependencies=deps)
 
-        # Assert against the first item in the returned list
         assert "Dependency not met" in str(result[0].error)
         assert mock_run.call_count == 1
 


### PR DESCRIPTION
Push large annotations (above the 15MiB serverside limit for a FileRecord) by splitting it into a two step push. This happens transparently.