### PR TITLE
fix: clean up model cli commands to avoid touching dorsal.registry

### DIFF
--- a/src/dorsal/api/model.py
+++ b/src/dorsal/api/model.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 import logging
+import pathlib
 import importlib.metadata
 import importlib.resources
 import tomllib
-from typing import Any, Callable, cast
+from typing import Any, Callable, Literal, cast
 
 from packaging.utils import canonicalize_name
+from pydantic import BaseModel
 
 from dorsal.api.config import get_model_pipeline
-from dorsal.common.exceptions import AuthError, DorsalError, DorsalConfigError
+from dorsal.common.constants import WEB_URL
+from dorsal.common.exceptions import AuthError, DorsalError, DorsalConfigError, NotFoundError
 from dorsal.common.validators import CallableImportPath
 from dorsal.file.configs.model_runner import ModelRunnerPipelineStep, resolve_pipeline_step_models, RunModelResult
 from dorsal.file.file_annotator import FILE_ANNOTATOR
@@ -29,10 +32,143 @@ from dorsal.file.model_runner import ModelRunner, run_model
 from dorsal.file.validators.file_record import Annotation, AnnotationGroup
 from dorsal.registry.installer import install_model_target
 from dorsal.registry.resolution import resolve_target, is_package_installed
+from dorsal.registry.validators import is_registry_id, is_valid_local_path
+from dorsal.registry.uninstaller import uninstall_model_target
+from dorsal.registry.initialize import create_new_annotation_model_project
+from dorsal.session import get_shared_dorsal_client
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["run_or_install_model"]
+__all__ = ["get_model_help", "run_or_install_model", "install_model", "uninstall_model", "init_model_project"]
+
+
+class ModelMetadata(BaseModel):
+    """Encapsulates display metadata for the CLI security prompts."""
+
+    description: str | None = None
+    url: str | None = None
+    source_url: str | None = None
+    is_verified: bool = False
+    is_official: bool = False
+    published_date: str | None = None
+
+
+class ModelTargetResolution(BaseModel):
+    """The structured intent payload instructing the CLI how to proceed."""
+
+    target: str
+    strategy: Literal["pipeline", "registry_id", "local_path", "package", "error"]
+    package_name: str | None = None
+
+    is_installed: bool = False
+
+    metadata: ModelMetadata | None = None
+    error_message: str | None = None
+
+
+def prepare_model_target(target: str) -> ModelTargetResolution:
+    """
+    Evaluates a user string, fetches relevant metadata, and returns a
+    structured resolution plan without executing or installing anything.
+    """
+    pipeline = get_model_pipeline(scope="effective")
+    for step in pipeline:
+        if step.annotation_model.name == target:
+            return ModelTargetResolution(
+                target=target,
+                strategy="pipeline",
+                package_name=step.package_name or "dorsal",
+                is_installed=True,
+            )
+
+    if is_registry_id(target):
+        try:
+            _, package_name = resolve_target(target)
+            is_installed = is_package_installed(package_name)
+            client = get_shared_dorsal_client()
+            reg_data = client.get_registry_model(target)
+
+            source_url = None
+            if reg_data.install_url:
+                source_url = reg_data.install_url.replace("git+", "").split("@")[0]
+
+            metadata = ModelMetadata(
+                description=reg_data.description,
+                url=f"{WEB_URL}/models/{reg_data.namespace}/{reg_data.name}",
+                source_url=source_url,
+                is_verified=reg_data.is_verified,
+                is_official=reg_data.is_official,
+                published_date=reg_data.created_at.date().isoformat() if reg_data.created_at else None,
+            )
+
+            return ModelTargetResolution(
+                target=target,
+                strategy="registry_id",
+                package_name=package_name,
+                is_installed=is_installed,
+                metadata=metadata,
+            )
+        except (AuthError, NotFoundError) as e:
+            return ModelTargetResolution(target=target, strategy="error", error_message=str(e))
+        except Exception as e:
+            logger.debug(f"Failed to fetch metadata for {target}: {e}")
+            return ModelTargetResolution(
+                target=target, strategy="error", error_message=f"Registry connection failed: {e}"
+            )
+
+    if target.startswith((".", "/", "~")) or is_valid_local_path(target):
+        return ModelTargetResolution(
+            target=target,
+            strategy="local_path",
+            is_installed=False,
+        )
+
+    safe_pkg_name = canonicalize_name(target)
+
+    if is_package_installed(safe_pkg_name):
+        return ModelTargetResolution(
+            target=target,
+            strategy="package",
+            package_name=safe_pkg_name,
+            is_installed=True,
+        )
+
+    return ModelTargetResolution(
+        target=target,
+        strategy="error",
+        error_message=f"Model '{target}' is not installed.",
+    )
+
+
+def init_model_project(name: str, target_dir: pathlib.Path | None = None):
+    """API wrapper to scaffold a new model directory."""
+    return create_new_annotation_model_project(name=name, target_dir=target_dir)
+
+
+def install_model(target: str, scope: Literal["project", "global"] = "project", force_reinstall: bool = False) -> str:
+    """API wrapper to install and register a model."""
+    res = prepare_model_target(target)
+
+    if res.strategy == "error":
+        raise DorsalError(res.error_message or f"Failed to resolve target '{target}'.")
+    if res.strategy == "pipeline":
+        raise DorsalError(f"Target '{target}' is a built-in core model and cannot be installed via pip.")
+
+    return install_model_target(target=target, scope=scope, force_reinstall=force_reinstall)
+
+
+def uninstall_model(target: str, scope: Literal["project", "global"] = "project") -> str:
+    """API wrapper to unregister and uninstall a model."""
+    res = prepare_model_target(target)
+
+    if res.strategy == "error":
+        raise DorsalError(res.error_message or f"Failed to resolve target '{target}'.")
+    if res.strategy == "pipeline":
+        raise DorsalError(
+            f"Target '{target}' is a built-in core model. Use 'dorsal config pipeline remove' instead of uninstalling."
+        )
+
+    return uninstall_model_target(target=target, scope=scope)
 
 
 def run_or_install_model(
@@ -43,39 +179,30 @@ def run_or_install_model(
     ignore_linter_errors: bool = False,
     progress_callback: Callable[[float, float, str], None] | None = None,
 ) -> list[RunModelResult]:
-    """
-    Resolve a model, installs if necessary, and execute it on a local file.
 
-    Args:
-        target: A Registry ID ('dorsalhub/whisper'), Package Name ('dorsal-whisper'),
-                or Class Name ('FasterWhisperTranscriber').
-        file_path: Path to the file to process.
-        api_key: Optional API key.
-        options: Runtime options to override the model's defaults.
-        ignore_linter_errors: If True, bypasses data quality checks.
-
-    Returns:
-        Annotation | AnnotationGroup: The final, validated annotation object(s).
-    """
     logger.info(f"Requesting run for model target '{target}' on file '{file_path}'")
 
-    strategy, package_name = resolve_target(target)
+    res = prepare_model_target(target)
 
-    if not is_package_installed(package_name):
-        if strategy == "registry_id":
-            logger.info(f"Model package '{package_name}' is not installed. Installing from '{target}'...")
-            try:
-                install_model_target(target)
-                logger.info(f"Successfully installed '{package_name}'.")
-            except Exception as e:
-                raise DorsalError(f"Failed to auto-install model '{target}': {e}") from e
+    if res.strategy == "error":
+        raise DorsalError(res.error_message or f"Failed to resolve target '{target}'.")
+
+    if not res.is_installed:
+        if res.strategy in ("registry_id", "local_path"):
+            logger.info(f"Model '{target}' is not installed. Auto-installing...")
+            res.package_name = install_model_target(target)
+            res.is_installed = True
         else:
-            message = f"The model '{target}' is not installed locally.\n"
-            if target == ".":
-                message += "For local development, install the model before running it."
-            raise DorsalError(message)
+            raise DorsalError(f"Model '{target}' is not installed and cannot be auto-installed.")
 
-    pipeline_step = _get_execution_step(package_name)
+    if res.strategy == "pipeline":
+        pipeline = get_model_pipeline(scope="effective")
+        pipeline_step = next(step for step in pipeline if step.annotation_model.name == target)
+        logger.debug(f"Target '{target}' resolved directly to active pipeline step.")
+    else:
+        if not res.package_name:
+            raise DorsalError(f"Could not determine package name for target '{target}'.")
+        pipeline_step = _construct_step_from_package(res.package_name)
 
     if options or ignore_linter_errors:
         pipeline_step = pipeline_step.model_copy(deep=True)
@@ -85,14 +212,11 @@ def run_or_install_model(
             pipeline_step.ignore_linter_errors = True
 
     annotator_class, validator = resolve_pipeline_step_models(pipeline_step)
+    effective_validator = (
+        None if (pipeline_step.schema_id and pipeline_step.schema_id.startswith("open/")) else validator
+    )
 
-    if pipeline_step.schema_id and pipeline_step.schema_id.startswith("open/"):
-        effective_validator = None
-    else:
-        effective_validator = validator
-
-    # 2. Delegate directly to run_model
-    run_result = run_model(
+    return run_model(
         annotation_model=annotator_class,
         file_path=file_path,
         schema_id=pipeline_step.schema_id,
@@ -104,22 +228,20 @@ def run_or_install_model(
         progress_callback=progress_callback,
     )
 
-    return run_result
 
-
-def _get_execution_step(package_name: str) -> ModelRunnerPipelineStep:
-    """Retrieves ModelRunnerPipelineStep for the given package."""
-
+def _find_pipeline_step_by_target(target: str) -> ModelRunnerPipelineStep | None:
+    """Finds a target model directly within the effective pipeline configuration."""
     pipeline = get_model_pipeline(scope="effective")
-    safe_pkg_name = canonicalize_name(package_name)
+    safe_target = canonicalize_name(target)
 
     for step in pipeline:
-        if step.package_name and canonicalize_name(step.package_name) == safe_pkg_name:
-            logger.debug(f"Found existing pipeline configuration for '{package_name}'.")
+        if step.annotation_model.name == target:
             return step
 
-    logger.debug(f"No pipeline config found for '{package_name}'. Constructing ephemeral step from package.")
-    return _construct_step_from_package(package_name)
+        if step.package_name and canonicalize_name(step.package_name) == safe_target:
+            return step
+
+    return None
 
 
 def _construct_step_from_package(package_name: str) -> ModelRunnerPipelineStep:
@@ -180,9 +302,8 @@ def _build_pipeline_step(config_data: dict[str, Any], module_name: str, package_
     parsed_options = {}
 
     for key, value in raw_options.items():
-        if isinstance(value, dict) and ("default" in value or "help" in value):
-            if "default" in value:
-                parsed_options[key] = value["default"]
+        if isinstance(value, dict) and "default" in value:
+            parsed_options[key] = value["default"]
         else:
             parsed_options[key] = value
 
@@ -193,7 +314,7 @@ def _build_pipeline_step(config_data: dict[str, Any], module_name: str, package_
             schema_version=config_data.get("schema_version"),
             dependencies=config_data.get("dependencies"),
             validation_model=None,
-            options=config_data.get("options"),
+            options=parsed_options,
             package_name=package_name,
         )
     except Exception as e:
@@ -207,45 +328,63 @@ def get_model_help(target: str) -> dict[str, Any]:
     Returns a dictionary containing the model's status, package info,
     and normalized options (default values & help strings).
     """
-    try:
-        strategy, package_name = resolve_target(target)
-    except (DorsalError, AuthError) as e:
-        return {
-            "status": "error",
-            "target": target,
-            "error": str(e),
-        }
+    res = prepare_model_target(target)
 
-    if not is_package_installed(package_name):
-        return {
-            "status": "not_installed",
-            "target": target,
-            "package_name": package_name,
-        }
+    if res.strategy == "error":
+        return {"status": "error", "target": target, "error": res.error_message or "Unknown error"}
 
-    try:
-        module_name = _resolve_module_from_package(package_name)
-        config_data = _load_package_config(module_name, package_name)
-    except Exception as e:
-        return {
-            "status": "config_error",
-            "target": target,
-            "package_name": package_name,
-            "error": str(e),
-        }
+    if not res.is_installed:
+        return {"status": "not_installed", "target": target, "package_name": res.package_name}
+
+    package_name: str
+    if res.strategy == "pipeline":
+        pipeline = get_model_pipeline(scope="effective")
+        pipeline_step = next((step for step in pipeline if step.annotation_model.name == target), None)
+
+        if pipeline_step:
+            package_name = pipeline_step.package_name or "dorsal"
+            module_name = pipeline_step.annotation_model.module
+            model_class = pipeline_step.annotation_model.name
+
+            try:
+                config_data = _load_package_config(module_name, package_name)
+            except DorsalConfigError:
+                logger.debug(f"No model_config.toml found for {model_class}, using pipeline options.")
+                config_data = {"model_class": model_class, "options": pipeline_step.options or {}}
+        else:
+            return {"status": "error", "target": target, "error": f"Failed to retrieve pipeline step for {target}"}
+    else:
+        if not res.package_name:
+            return {"status": "error", "target": target, "error": f"No package name found for target '{target}'."}
+        package_name = res.package_name
+        try:
+            module_name = _resolve_module_from_package(package_name)
+            config_data = _load_package_config(module_name, package_name)
+        except Exception as e:
+            return {"status": "config_error", "target": target, "package_name": package_name, "error": str(e)}
 
     raw_options = config_data.get("options", {})
     normalized_options: dict[str, dict[str, Any]] = {}
 
     for opt_key, opt_val in raw_options.items():
         if isinstance(opt_val, dict):
+            opt_type = opt_val.get("type")
+
+            if not opt_type and "default" in opt_val:
+                opt_type = type(opt_val["default"]).__name__
+
+            elif not opt_type:
+                opt_type = "str"
+
             normalized_options[opt_key] = {
-                "default": opt_val.get("default", ""),
+                "default": opt_val.get("default", None),
+                "type": opt_type,
                 "help": opt_val.get("help", "No description provided."),
             }
         else:
             normalized_options[opt_key] = {
                 "default": opt_val,
+                "type": type(opt_val).__name__,
                 "help": "No description provided.",
             }
 

--- a/src/dorsal/cli/model_app/checks.py
+++ b/src/dorsal/cli/model_app/checks.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from __future__ import annotations
 import logging
 import sys
 import shutil
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from rich.panel import Panel
 from rich.console import Group
@@ -26,21 +26,28 @@ import typer
 from dorsal.cli.themes import UIContext
 from dorsal.cli.themes.borders import get_borders
 
+if TYPE_CHECKING:
+    from dorsal.api.model import ModelTargetResolution
+
 
 logger = logging.getLogger(__name__)
 
 
-def check_and_confirm_model_install(target: str, ui_context: UIContext, force: bool = False, yes: bool = False) -> None:
+def check_and_confirm_model_install(
+    resolution: "ModelTargetResolution", ui_context: UIContext, force: bool = False, yes: bool = False
+) -> None:
     """
-    Checks if a model target is safe to install and prompts the user for confirmation.
+    Renders security prompts using the structured intent payload from the API.
     """
-    from dorsal.common.constants import WEB_URL
-    from dorsal.common.exceptions import AuthError
-    from dorsal.common.cli import exit_cli, get_error_console
-    from dorsal.session import get_shared_dorsal_client
-    from dorsal.registry.validators import is_registry_id
+    from dorsal.common.cli import exit_cli, EXIT_CODE_ERROR, get_error_console
 
-    if force or yes:
+    is_unverified = resolution.strategy == "local_path" or (
+        resolution.strategy == "registry_id"
+        and resolution.metadata
+        and not (resolution.metadata.is_verified or resolution.metadata.is_official)
+    )
+
+    if force or yes or not is_unverified:
         return
 
     error_console = get_error_console()
@@ -53,48 +60,32 @@ def check_and_confirm_model_install(target: str, ui_context: UIContext, force: b
             "The model will be available to the CLI, but NOT to external Python scripts.[/]"
         )
 
-    display_meta = {"Model": target, "Source": "Local Path"}
+    display_meta = {"Model": resolution.target, "Source": "Local Path"}
     status_badge = f"[{palette.get('warning', 'bold yellow')}]Unverified[/]"
     border_style = palette.get("panel_border_warning", "yellow")
     link_style = palette.get("link", "blue underline")
 
-    if is_registry_id(target):
-        try:
-            with error_console.status(f"[{palette.get('info', 'dim')}]Fetching model details...[/]"):
-                client = get_shared_dorsal_client()
-                reg_data = client.get_registry_model(target)
+    if resolution.metadata:
+        meta = resolution.metadata
+        if meta.is_official or meta.is_verified:
+            status_badge = f"[{palette.get('panel_border', 'bold blue')}]Verified[/]"
+            border_style = palette.get("panel_border", "blue")
 
-                if reg_data.is_official or reg_data.is_verified:
-                    status_badge = f"[{palette.get('panel_border', 'bold blue')}]Verified[/]"
-                    border_style = palette.get("panel_border", "blue")
+        display_meta = {
+            "Model": resolution.target,
+            "Status": status_badge,
+        }
+        if meta.url:
+            display_meta["URL"] = f"[{link_style} link={meta.url}]{meta.url}[/]"
+        display_meta["Description"] = meta.description or "No description provided."
 
-                dorsalhub_url = f"{WEB_URL}/models/{reg_data.namespace}/{reg_data.name}"
-                display_meta = {
-                    "Model": f"{reg_data.namespace}/{reg_data.name}",
-                    "Status": status_badge,
-                    "URL": f"[{link_style} link={dorsalhub_url}]{dorsalhub_url}[/]",
-                    "Description": reg_data.description or "No description provided.",
-                }
+        if meta.source_url:
+            if not shutil.which("git"):
+                _handle_missing_git(ui_context)
+            display_meta["Source Code"] = f"[{link_style} link={meta.source_url}]{meta.source_url}[/]"
 
-                if reg_data.install_url:
-                    if reg_data.install_url.startswith("git+") and not shutil.which("git"):
-                        _handle_missing_git(ui_context)
-
-                    raw_url = reg_data.install_url.replace("git+", "").split("@")[0]
-                    display_meta["Source Code"] = f"[{link_style} link={raw_url}]{raw_url}[/]"
-
-                if reg_data.created_at:
-                    display_meta["Published"] = reg_data.created_at.date().isoformat()
-
-        except AuthError:
-            raise
-        except typer.Exit:
-            raise
-        except Exception as e:
-            logger.debug(f"Metadata fetch failed: {e}")
-            if "/" in target:
-                _handle_registry_error(target, e, ui_context)
-            display_meta["Warning"] = "Could not fetch remote metadata."
+        if meta.published_date:
+            display_meta["Published"] = meta.published_date
 
     msg_lines = []
     for k, v in display_meta.items():
@@ -111,13 +102,7 @@ def check_and_confirm_model_install(target: str, ui_context: UIContext, force: b
         error_console.print(Group(Text.from_markup(f"\n{title_text}"), Text.from_markup("\n".join(msg_lines))))
     else:
         error_console.print(
-            Panel(
-                "\n".join(msg_lines),
-                title=title_text,
-                border_style=border_style,
-                expand=False,
-                box=borders,
-            )
+            Panel("\n".join(msg_lines), title=title_text, border_style=border_style, expand=False, box=borders)
         )
 
     if not Confirm.ask("Do you trust this source and want to proceed?", console=error_console):

--- a/src/dorsal/cli/model_app/init_model_cmd.py
+++ b/src/dorsal/cli/model_app/init_model_cmd.py
@@ -42,13 +42,14 @@ def init_model(
     from rich.panel import Panel
     from dorsal.common.exceptions import DorsalError
     from dorsal.common.cli import exit_cli, EXIT_CODE_ERROR, get_rich_console
-    from dorsal.registry.initialize import create_new_annotation_model_project
+
+    from dorsal.api.model import init_model_project
 
     console = get_rich_console()
     palette: dict[str, str] = ctx.obj["palette"]
 
     try:
-        result = create_new_annotation_model_project(name=name, target_dir=target_dir)
+        result = init_model_project(name=name, target_dir=target_dir)
 
         console.print(
             Panel(

--- a/src/dorsal/cli/model_app/install_model_cmd.py
+++ b/src/dorsal/cli/model_app/install_model_cmd.py
@@ -31,7 +31,7 @@ def install_model(
     global_install: Annotated[
         bool, typer.Option("--global", "-g", help="Install to global user config instead of project config.")
     ] = False,
-    force: Annotated[bool, typer.Option("--force", "-f", help="Force reinstall the pip package.")] = False,
+    force: Annotated[bool, typer.Option("--force-reinstall", "-f", help="Force reinstall the pip package.")] = False,
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip the safety confirmation prompt.")] = False,
 ):
     """
@@ -43,7 +43,8 @@ def install_model(
     from rich.panel import Panel
     from dorsal.common.exceptions import DorsalError, AuthError
     from dorsal.common.cli import exit_cli, EXIT_CODE_ERROR, get_rich_console
-    from dorsal.registry.installer import install_model_target
+
+    from dorsal.api.model import prepare_model_target, install_model as api_install_model
     from dorsal.cli.model_app.checks import check_and_confirm_model_install
 
     console = get_rich_console()
@@ -53,13 +54,17 @@ def install_model(
 
     scope: Literal["global", "project"] = "global" if global_install else "project"
 
-    # Pass the full ui_context to the checker so it can render borderless!
-    check_and_confirm_model_install(target, ui_context, force=force, yes=yes)
+    resolution = prepare_model_target(target)
+    if resolution.strategy == "error":
+        console.print(f"[{palette.get('error', 'bold red')}]Install Failed:[/] {resolution.error_message}")
+        exit_cli(code=EXIT_CODE_ERROR)
+
+    check_and_confirm_model_install(resolution, ui_context, force=force, yes=yes)
 
     status_color = palette.get("primary_value", "bold cyan")
     with console.status(f"Installing model from [{status_color}]{target}[/]..."):
         try:
-            package_name = install_model_target(target, scope=scope, force_reinstall=force)
+            package_name = api_install_model(target, scope=scope, force_reinstall=force)
 
         except AuthError:
             raise

--- a/src/dorsal/cli/model_app/run_model_cmd.py
+++ b/src/dorsal/cli/model_app/run_model_cmd.py
@@ -131,19 +131,17 @@ def run_model(
     """
     Run a model on a local file or directory.
 
-    If the model is not installed locally, Dorsal will attempt to fetch
-    and install it from the registry automatically.
+    If the model is not installed, Dorsal will attempt to fetch and install it.
     """
     if json_output and export_format:
         raise typer.BadParameter("You cannot use --json and --export at the same time for standard output.")
 
     from dorsal.common.exceptions import DorsalError, AuthError
     from dorsal.common.cli import EXIT_CODE_ERROR, exit_cli, get_rich_console, get_error_console, parse_cli_options
-    from dorsal.api.model import run_or_install_model
+    from dorsal.api.model import prepare_model_target, run_or_install_model
     from dorsal.api.adapters import export_record, get_format_extension
     from dorsal.cli.views.model import create_model_result_panel
     from dorsal.file.configs.model_runner import RunModelResult
-    from dorsal.registry.resolution import resolve_target, is_package_installed
     from dorsal.cli.model_app.checks import check_and_confirm_model_install
     from dorsal.cli.themes import UIContext
     from dorsal.cli.themes.borders import get_borders
@@ -174,15 +172,32 @@ def run_model(
     parsed_export_options = parse_cli_options(options=export_options, palette=palette)
 
     try:
-        _strategy, package_name = resolve_target(target)
-        if not is_package_installed(package_name):
+        resolution = prepare_model_target(target)
+
+        if resolution.strategy == "error":
+            error_console.print(f"[{palette.get('error', 'bold red')}]Error:[/] {resolution.error_message}")
+            exit_cli(code=EXIT_CODE_ERROR)
+
+        if not resolution.is_installed:
             if (json_output or export_format) and not yes:
                 error_console.print(
                     f"[{palette.get('info', 'dim')}]Running a model for the first time requires installation. "
                     "To bypass this interactive prompt in scripts, use the '--yes' flag."
                 )
 
-            check_and_confirm_model_install(target, ui_context, yes=yes)
+            is_unverified = resolution.strategy == "local_path" or (
+                resolution.strategy == "registry_id"
+                and resolution.metadata
+                and not (resolution.metadata.is_verified or resolution.metadata.is_official)
+            )
+
+            if is_unverified and not yes:
+                check_and_confirm_model_install(resolution, ui_context, yes=yes)
+            elif not yes and not is_unverified:
+                error_console.print(
+                    f"[{palette.get('info', 'dim')}]First time running '{target}'. It will be installed automatically.[/]"
+                )
+
     except typer.Exit:
         raise
     except Exception:
@@ -259,7 +274,6 @@ def run_model(
                         res_dict["file_path"] = str(f)
                         results_data.append(res_dict)
 
-                        # --- Export Alignment Logic ---
                         if export_format:
                             try:
                                 if res.error:
@@ -320,7 +334,6 @@ def run_model(
                                     f"[{palette.get('warning', 'yellow')}]Data Error on {f.name}:[/] {err}"
                                 )
                                 res_dict["export_error"] = str(err)
-                    # ------------------------------
 
                 except (DorsalError, AuthError, typer.Exit):
                     raise
@@ -428,7 +441,6 @@ def run_model(
                                 row.append(f"[{palette.get('error', 'bold red')}]Failed[/]")
                             else:
                                 exp_path = out_dir / f"{base_name}.{export_format}"
-                                # Note: For chunked outputs, this displays the base path as an indicator
                                 row.append(f"[{palette.get('primary_value', 'cyan')}]{exp_path.name}[/]")
 
                 table.add_row(*row)

--- a/src/dorsal/cli/model_app/uninstall_model_cmd.py
+++ b/src/dorsal/cli/model_app/uninstall_model_cmd.py
@@ -40,11 +40,25 @@ def uninstall_model(
     from rich.prompt import Confirm
     from dorsal.common.exceptions import DorsalError
     from dorsal.common.cli import exit_cli, EXIT_CODE_ERROR, get_rich_console
-    from dorsal.registry.uninstaller import uninstall_model_target
+
+    from dorsal.api.model import prepare_model_target, uninstall_model as api_uninstall_model
 
     console = get_rich_console()
     palette: dict[str, str] = ctx.obj["palette"]
     scope: Literal["global", "project"] = "global" if global_install else "project"
+
+    resolution = prepare_model_target(target)
+
+    if resolution.strategy == "error":
+        console.print(f"[{palette.get('error', 'bold red')}]Uninstall Failed:[/] {resolution.error_message}")
+        exit_cli(code=EXIT_CODE_ERROR)
+
+    if resolution.strategy == "pipeline":
+        console.print(
+            f"[{palette.get('error', 'bold red')}]Uninstall Failed:[/] "
+            f"Target '{target}' is a built-in core model. Use 'dorsal config pipeline remove' instead of uninstalling."
+        )
+        exit_cli(code=EXIT_CODE_ERROR)
 
     if not yes:
         message = (
@@ -60,7 +74,7 @@ def uninstall_model(
 
     with console.status(f"Uninstalling [{status_color}]{target}[/]..."):
         try:
-            package_name = uninstall_model_target(target, scope=scope)
+            package_name = api_uninstall_model(target, scope=scope)
 
         except DorsalError as e:
             console.print(f"[{palette.get('error', 'bold red')}]Uninstall Failed:[/] {e}")

--- a/src/dorsal/common/cli.py
+++ b/src/dorsal/common/cli.py
@@ -226,28 +226,14 @@ def parse_cli_options(options: Sequence[str] | None, palette: dict[str, str]) ->
         key = key.strip()
         value = value.strip()
 
-        val_lower = value.lower()
-        if val_lower in ("true", "yes"):
-            result[key] = True
-        elif val_lower in ("false", "no"):
-            result[key] = False
-        elif val_lower in ("null", "none"):
-            result[key] = None
-        else:
-            if (value.startswith("{") and value.endswith("}")) or (value.startswith("[") and value.endswith("]")):
-                try:
-                    result[key] = json.loads(value)
-                    continue
-                except json.JSONDecodeError:
-                    pass
-
+        if (value.startswith("{") and value.endswith("}")) or (value.startswith("[") and value.endswith("]")):
             try:
-                if "." in value:
-                    result[key] = float(value)
-                else:
-                    result[key] = int(value)
-            except ValueError:
-                result[key] = value
+                result[key] = json.loads(value)
+                continue
+            except json.JSONDecodeError:
+                pass
+
+        result[key] = value
 
     return result
 
@@ -345,8 +331,9 @@ def render_model_help_panel(help_info: dict[str, Any], ui_context: dict[str, Any
     status = help_info.get("status")
 
     if status == "error":
+        # Cleaned up error title and payload
         return Panel(
-            f"Could not resolve model target '{help_info['target']}': {help_info.get('error')}",
+            help_info.get("error", "Unknown error"),
             title="[bold yellow]Model Resolution Failed[/]",
             border_style="yellow",
             box=borders,
@@ -355,13 +342,23 @@ def render_model_help_panel(help_info: dict[str, Any], ui_context: dict[str, Any
     if status == "not_installed":
         target = help_info["target"]
         pkg = help_info["package_name"]
-        return Panel(
-            f"Model [bold cyan]{pkg}[/] is not installed locally.\n"
-            f"Run [bold]dorsal model install {target}[/] to install it and view its runtime options.",
-            title=f"Model: {target}",
-            border_style="cyan",
-            box=borders,
-        )
+
+        if "/" in target:
+            return Panel(
+                f"Registry model [bold cyan]{target}[/] (package: [bold]{pkg}[/]) is not installed.\n"
+                f"Run [bold]dorsal model install {target}[/] to install it and view its runtime options.",
+                title=f"Model: {target}",
+                border_style="cyan",
+                box=borders,
+            )
+        else:
+            return Panel(
+                f"Model [bold cyan]{target}[/] is not installed.\n"
+                f"To install a model from DorsalHub, use its full model ID in [bold]organization/project[/] format, e.g. [bold]dorsalhub/whisper[/]",
+                title=f"Model: {target}",
+                border_style="cyan",
+                box=borders,
+            )
 
     if status == "config_error":
         return Panel(
@@ -384,13 +381,34 @@ def render_model_help_panel(help_info: dict[str, Any], ui_context: dict[str, Any
 
     table = Table(show_header=True, header_style="bold", box=None, expand=True)
     table.add_column("Option", style=palette.get("primary_value", "cyan"), width=20)
-    table.add_column("Default Value", style="magenta", width=15)
+    table.add_column("Type", style="green", width=10)
+    table.add_column("Default", style="magenta", width=15)
     table.add_column("Description", style="default")
 
-    for opt_key, opt_data in options.items():
-        table.add_row(opt_key, str(opt_data.get("default", "N/A")), opt_data.get("help", "No description provided."))
+    type_ui_mapping = {
+        "str": "String",
+        "int": "Integer",
+        "float": "Float",
+        "bool": "Boolean",
+        "dict": "JSON",
+        "list": "Array",
+    }
 
-    footer = Text("\nNote: You can pass additional, undeclared keyword arguments via --opt.", style="dim")
+    for opt_key, opt_data in options.items():
+        raw_type = opt_data.get("type", "str")
+        display_type = type_ui_mapping.get(raw_type, raw_type.capitalize())
+
+        default_val = opt_data.get("default")
+        if default_val is None:
+            default_str = "<unassigned>"
+        elif default_val == "":
+            default_str = '""'
+        else:
+            default_str = str(default_val)
+
+        table.add_row(opt_key, display_type, default_str, opt_data.get("help", "No description provided."))
+
+    footer = Text("\nPass model options via --opt.", style="dim")
 
     return Panel(
         Group(table, footer),

--- a/src/dorsal/file/model_runner.py
+++ b/src/dorsal/file/model_runner.py
@@ -170,6 +170,62 @@ class ModelRunner:
             self.pipeline_config_source,
         )
 
+    @staticmethod
+    def _get_schema_for_model(annotator_class: Type[AnnotationModel]) -> dict[str, str]:
+        """Extracts expected types from the model's model_config.toml, if available."""
+        import importlib.resources
+        import tomllib
+
+        try:
+            resource_path = importlib.resources.files(annotator_class.__module__) / "model_config.toml"
+            if resource_path.is_file():
+                config_data = tomllib.loads(resource_path.read_text(encoding="utf-8"))
+                raw_options = config_data.get("options", {})
+                schema = {}
+                for k, v in raw_options.items():
+                    if isinstance(v, dict):
+                        if "type" in v:
+                            schema[k] = v["type"]
+                        elif "default" in v:
+                            schema[k] = type(v["default"]).__name__
+                        else:
+                            schema[k] = "str"
+                    else:
+                        schema[k] = type(v).__name__
+                return schema
+        except Exception as e:
+            logger.debug("Could not extract schema for %s: %s", annotator_class.__name__, e)
+
+        return {}
+
+    @staticmethod
+    def _coerce_options(raw_options: dict[str, Any], schema: dict[str, str]) -> dict[str, Any]:
+        """Safely coerces string options into their expected types based on the schema."""
+        coerced = {}
+        for key, val in raw_options.items():
+            if key not in schema or not isinstance(val, str):
+                coerced[key] = val
+                continue
+
+            expected_type = schema[key].lower()
+
+            if expected_type in ("bool", "boolean"):
+                coerced[key] = val.lower() in ("true", "yes", "1", "t", "y")
+            elif expected_type in ("int", "integer"):
+                try:
+                    coerced[key] = int(val)
+                except ValueError:
+                    coerced[key] = val
+            elif expected_type in ("float", "double"):
+                try:
+                    coerced[key] = float(val)
+                except ValueError:
+                    coerced[key] = val
+            else:
+                coerced[key] = val
+
+        return coerced
+
     def _load_pre_pipeline_model_step(self) -> ModelRunnerPipelineStep:
         from dorsal.file.configs.model_runner import (
             BASE_ANNOTATION_MODEL,
@@ -622,10 +678,13 @@ class ModelRunner:
                         continue
                     setattr(annotation_model_instance, key, value)
 
-            logger.debug("Running model '%s' main method with options: %s", model_name, options or "None")
+            expected_schema = self._get_schema_for_model(annotation_model)
+            safe_options = self._coerce_options(options, expected_schema) if options else {}
+
+            logger.debug("Running model '%s' main method with safe options: %s", model_name, safe_options or "None")
 
             raw_model_output: Any = (
-                annotation_model_instance.main(**options) if options else annotation_model_instance.main()
+                annotation_model_instance.main(**safe_options) if safe_options else annotation_model_instance.main()
             )
 
             named_outputs: list[tuple[str | None, Any]] = []

--- a/src/dorsal/registry/installer.py
+++ b/src/dorsal/registry/installer.py
@@ -279,12 +279,20 @@ def install_model_from_package(
                 f"Config defines model_class='{class_name}', but it was not exported by module '{module_name}' - {err}"
             ) from err
 
+        raw_options = toml_config.get("options", {})
+        flat_options = {}
+        for key, value in raw_options.items():
+            if isinstance(value, dict) and "default" in value:
+                flat_options[key] = value["default"]
+            elif not isinstance(value, dict):
+                flat_options[key] = value
+
         merged_config = {
             "model_class": model_class,
             "schema_id": toml_config.get("schema_id", "open/generic"),
             "schema_version": toml_config.get("schema_version"),
             "dependencies": toml_config.get("dependencies"),
-            "options": toml_config.get("options", {}),
+            "options": flat_options,  # <--- FIXED
         }
 
         spec = ModelSpec(**merged_config)

--- a/src/dorsal/registry/resolution.py
+++ b/src/dorsal/registry/resolution.py
@@ -18,8 +18,8 @@ from typing import Literal
 
 from packaging.utils import canonicalize_name
 
-from dorsal.api.config import find_package_name_by_class
-from dorsal.common.exceptions import DorsalError, AuthError
+from dorsal.api.config import find_package_name_by_class, get_model_pipeline
+from dorsal.common.exceptions import DorsalError, AuthError, NotFoundError
 from dorsal.registry.validators import is_registry_id
 from dorsal.session import get_shared_dorsal_client
 
@@ -59,10 +59,12 @@ def resolve_target(target: str) -> tuple[TargetModelStrategy, str]:
             raw_package_name = reg_data.package_name
             strategy = "registry_id"
             logger.debug(f"Registry ID '{target}' resolved to '{raw_package_name}'")
-        except AuthError as e:
-            raise e
-        except Exception as e:
-            raise DorsalError(f"Failed to resolve model '{target}' in registry: {e}") from e
+        except AuthError as err:
+            raise err
+        except NotFoundError as err:
+            raise DorsalError(f"Remote model '{target}' not found.") from err
+        except Exception as err:
+            raise DorsalError(f"Failed to resolve model '{target}' in registry: {err}") from err
 
     if not raw_package_name:
         resolved_from_config = find_package_name_by_class(target)
@@ -70,6 +72,14 @@ def resolve_target(target: str) -> tuple[TargetModelStrategy, str]:
             raw_package_name = resolved_from_config
             strategy = "package"
             logger.debug(f"Class Name '{target}' resolved to '{raw_package_name}'")
+        else:
+            pipeline = get_model_pipeline(scope="effective")
+            for step in pipeline:
+                if step.annotation_model.name == target:
+                    raw_package_name = "dorsal"
+                    strategy = "class_name"
+                    logger.debug(f"Target '{target}' resolved to built-in package 'dorsal'")
+                    break
 
     if not raw_package_name:
         raw_package_name = target

--- a/src/dorsal/session.py
+++ b/src/dorsal/session.py
@@ -126,8 +126,8 @@ def clear_shared_index() -> None:
     if _DORSAL_INDEX is not None:
         try:
             _DORSAL_INDEX.close()
-        except Exception as e:
-            logger.warning(f"Error closing shared index: {e}")
+        except Exception as err:
+            logger.warning(f"Error closing shared index: {err}")
 
     _DORSAL_INDEX = None
     logger.debug("Cleared shared DorsalIndex instance")

--- a/tests/api/test_api_model.py
+++ b/tests/api/test_api_model.py
@@ -23,11 +23,13 @@ from dorsal.api.model import (
     run_or_install_model,
     install_model,
     uninstall_model,
+    init_model_project,
     _build_pipeline_step,
+    _find_pipeline_step_by_target,
     get_model_help,
     ModelTargetResolution,
 )
-from dorsal.common.exceptions import DorsalError, DorsalConfigError
+from dorsal.common.exceptions import DorsalError, DorsalConfigError, AuthError, NotFoundError
 from dorsal.common.validators import CallableImportPath
 from dorsal.file.configs.model_runner import ModelRunnerPipelineStep
 
@@ -116,12 +118,52 @@ def test_prepare_model_target_registry(mock_client, mock_installed, mock_resolve
     assert res.metadata.source_url == "https://github.com/a/b.git"
 
 
+@patch("dorsal.api.model.get_shared_dorsal_client")
+@patch("dorsal.api.model.resolve_target")
+@patch("dorsal.api.model.get_model_pipeline")
+def test_prepare_model_target_registry_exceptions(mock_pipeline, mock_resolve, mock_client):
+    mock_pipeline.return_value = []
+    mock_resolve.return_value = ("registry_id", "my-pkg")
+
+    mock_client.return_value.get_registry_model.side_effect = AuthError("Bad token")
+    res = prepare_model_target("dorsalhub/whisper")
+    assert res.strategy == "error"
+    assert "Bad token" in res.error_message
+
+    mock_client.return_value.get_registry_model.side_effect = Exception("Boom")
+    res = prepare_model_target("dorsalhub/whisper")
+    assert res.strategy == "error"
+    assert "Registry connection failed: Boom" in res.error_message
+
+
 @patch("dorsal.api.model.get_model_pipeline")
 def test_prepare_model_target_local_path(mock_pipeline):
     mock_pipeline.return_value = []
     res = prepare_model_target("./local-model-dir")
     assert res.strategy == "local_path"
     assert res.is_installed is False
+
+
+@patch("dorsal.api.model.is_package_installed")
+@patch("dorsal.api.model.get_model_pipeline")
+def test_prepare_model_target_package_and_fallback(mock_pipeline, mock_is_installed):
+    mock_pipeline.return_value = []
+    mock_is_installed.return_value = True
+    res = prepare_model_target("some-package")
+    assert res.strategy == "package"
+    assert res.package_name == "some-package"
+
+    mock_is_installed.return_value = False
+    res = prepare_model_target("some-package")
+    assert res.strategy == "error"
+    assert "is not installed" in res.error_message
+
+
+@patch("dorsal.api.model.create_new_annotation_model_project")
+def test_init_model_project(mock_create):
+    mock_create.return_value = "success"
+    assert init_model_project("MyModel", None) == "success"
+    mock_create.assert_called_once_with(name="MyModel", target_dir=None)
 
 
 @patch("dorsal.api.model.prepare_model_target")
@@ -140,6 +182,10 @@ def test_install_model_wrapper(mock_install_target, mock_prepare):
     with pytest.raises(DorsalError, match="Network Fail"):
         install_model("foo")
 
+    mock_prepare.return_value = ModelTargetResolution(target="foo", strategy="error", error_message=None)
+    with pytest.raises(DorsalError, match="Failed to resolve target 'foo'."):
+        install_model("foo")
+
 
 @patch("dorsal.api.model.prepare_model_target")
 @patch("dorsal.api.model.uninstall_model_target")
@@ -151,6 +197,10 @@ def test_uninstall_model_wrapper(mock_uninstall_target, mock_prepare):
     mock_prepare.return_value = ModelTargetResolution(target="BuiltIn", strategy="pipeline")
     with pytest.raises(DorsalError, match="Use 'dorsal config pipeline remove'"):
         uninstall_model("BuiltIn")
+
+    mock_prepare.return_value = ModelTargetResolution(target="foo", strategy="error", error_message=None)
+    with pytest.raises(DorsalError, match="Failed to resolve target 'foo'."):
+        uninstall_model("foo")
 
 
 def test_run_or_install_model_happy_path_existing_pipeline(
@@ -273,6 +323,14 @@ def test_run_or_install_model_auto_install_failure(mock_prepare_model_target, mo
         run_or_install_model(target, "file.txt")
 
 
+def test_run_or_install_model_cannot_autoinstall(mock_prepare_model_target):
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target="my-pkg", strategy="package", is_installed=False
+    )
+    with pytest.raises(DorsalError, match="cannot be auto-installed"):
+        run_or_install_model("my-pkg", "f.txt")
+
+
 def test_construct_step_missing_entry_point(mock_prepare_model_target, mock_entry_points):
     target = "dorsal-ghost"
     mock_prepare_model_target.return_value = ModelTargetResolution(
@@ -326,6 +384,23 @@ def test_build_pipeline_step_options_parsing():
     assert step.options == {"flat_val": "value", "dict_with_default": 42, "dict_no_default": {"help": "just help text"}}
 
 
+@patch("dorsal.api.model.get_model_pipeline")
+def test_find_pipeline_step_by_target(mock_pipeline):
+    step1 = MagicMock()
+    step1.annotation_model.name = "ModelOne"
+    step1.package_name = "pkg-one"
+
+    step2 = MagicMock()
+    step2.annotation_model.name = "ModelTwo"
+    step2.package_name = "pkg-two"
+
+    mock_pipeline.return_value = [step1, step2]
+
+    assert _find_pipeline_step_by_target("ModelOne") == step1
+    assert _find_pipeline_step_by_target("pkg-two") == step2
+    assert _find_pipeline_step_by_target("Missing") is None
+
+
 @patch("dorsal.api.model.prepare_model_target")
 def test_get_model_help_resolve_error(mock_prepare):
     mock_prepare.return_value = ModelTargetResolution(
@@ -344,6 +419,39 @@ def test_get_model_help_not_installed(mock_prepare):
     res = get_model_help("my-pkg")
     assert res["status"] == "not_installed"
     assert res["package_name"] == "my-pkg"
+
+
+@patch("dorsal.api.model.prepare_model_target")
+def test_get_model_help_no_package_name(mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(
+        target="tgt", strategy="package", is_installed=True, package_name=None
+    )
+    res = get_model_help("tgt")
+    assert res["status"] == "error"
+    assert "No package name found" in res["error"]
+
+
+@patch("dorsal.api.model.prepare_model_target")
+@patch("dorsal.api.model.get_model_pipeline")
+@patch("dorsal.api.model._load_package_config")
+def test_get_model_help_pipeline_branches(mock_load, mock_pipeline, mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(target="Missing", strategy="pipeline", is_installed=True)
+    mock_pipeline.return_value = []
+    res = get_model_help("Missing")
+    assert res["status"] == "error"
+    assert "Failed to retrieve pipeline step" in res["error"]
+
+    mock_prepare.return_value = ModelTargetResolution(target="Found", strategy="pipeline", is_installed=True)
+    step = MagicMock()
+    step.annotation_model.name = "Found"
+    step.package_name = "pkg"
+    step.options = {"my_opt": 1}
+    mock_pipeline.return_value = [step]
+
+    mock_load.side_effect = DorsalConfigError("No config")
+    res = get_model_help("Found")
+    assert res["status"] == "success"
+    assert res["options"]["my_opt"]["default"] == 1
 
 
 @patch("dorsal.api.model.prepare_model_target")

--- a/tests/api/test_api_model.py
+++ b/tests/api/test_api_model.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib.metadata
-import importlib.resources
 import tomllib
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
 
 from dorsal.api.model import (
+    prepare_model_target,
     run_or_install_model,
+    install_model,
+    uninstall_model,
     _build_pipeline_step,
     get_model_help,
+    ModelTargetResolution,
 )
 from dorsal.common.exceptions import DorsalError, DorsalConfigError
 from dorsal.common.validators import CallableImportPath
@@ -32,20 +33,8 @@ from dorsal.file.configs.model_runner import ModelRunnerPipelineStep
 
 
 @pytest.fixture
-def mock_resolve_target():
-    with patch("dorsal.api.model.resolve_target") as mock:
-        yield mock
-
-
-@pytest.fixture
-def mock_is_package_installed():
-    with patch("dorsal.api.model.is_package_installed") as mock:
-        yield mock
-
-
-@pytest.fixture
-def mock_install_model_target():
-    with patch("dorsal.api.model.install_model_target") as mock:
+def mock_prepare_model_target():
+    with patch("dorsal.api.model.prepare_model_target") as mock:
         yield mock
 
 
@@ -69,6 +58,12 @@ def mock_run_model():
 
 
 @pytest.fixture
+def mock_install_model_target():
+    with patch("dorsal.api.model.install_model_target") as mock:
+        yield mock
+
+
+@pytest.fixture
 def mock_entry_points():
     with patch("importlib.metadata.entry_points") as mock:
         yield mock
@@ -80,26 +75,100 @@ def mock_resources_files():
         yield mock
 
 
+@patch("dorsal.api.model.get_model_pipeline")
+def test_prepare_model_target_pipeline(mock_pipeline):
+    step = MagicMock()
+    step.annotation_model.name = "BuiltInModel"
+    step.package_name = "dorsal-builtin"
+    mock_pipeline.return_value = [step]
+
+    res = prepare_model_target("BuiltInModel")
+    assert res.strategy == "pipeline"
+    assert res.is_installed is True
+    assert res.package_name == "dorsal-builtin"
+
+
+@patch("dorsal.api.model.get_model_pipeline")
+@patch("dorsal.api.model.resolve_target")
+@patch("dorsal.api.model.is_package_installed")
+@patch("dorsal.api.model.get_shared_dorsal_client")
+def test_prepare_model_target_registry(mock_client, mock_installed, mock_resolve, mock_pipeline):
+    mock_pipeline.return_value = []
+    mock_resolve.return_value = ("registry_id", "my-pkg")
+    mock_installed.return_value = False
+
+    mock_reg_data = MagicMock()
+    mock_reg_data.install_url = "git+https://github.com/a/b.git@abc"
+    mock_reg_data.description = "Test description"
+    mock_reg_data.namespace = "dorsalhub"
+    mock_reg_data.name = "whisper"
+    mock_reg_data.is_verified = True
+    mock_reg_data.is_official = False
+    mock_reg_data.created_at = None
+    mock_client.return_value.get_registry_model.return_value = mock_reg_data
+
+    res = prepare_model_target("dorsalhub/whisper")
+    assert res.strategy == "registry_id"
+    assert res.is_installed is False
+    assert res.package_name == "my-pkg"
+    assert res.metadata is not None
+    assert res.metadata.is_verified is True
+    assert res.metadata.source_url == "https://github.com/a/b.git"
+
+
+@patch("dorsal.api.model.get_model_pipeline")
+def test_prepare_model_target_local_path(mock_pipeline):
+    mock_pipeline.return_value = []
+    res = prepare_model_target("./local-model-dir")
+    assert res.strategy == "local_path"
+    assert res.is_installed is False
+
+
+@patch("dorsal.api.model.prepare_model_target")
+@patch("dorsal.api.model.install_model_target")
+def test_install_model_wrapper(mock_install_target, mock_prepare):
+
+    mock_prepare.return_value = ModelTargetResolution(target="foo/bar", strategy="registry_id")
+    mock_install_target.return_value = "dorsal-bar"
+    assert install_model("foo/bar") == "dorsal-bar"
+
+    mock_prepare.return_value = ModelTargetResolution(target="BuiltIn", strategy="pipeline")
+    with pytest.raises(DorsalError, match="built-in core model"):
+        install_model("BuiltIn")
+
+    mock_prepare.return_value = ModelTargetResolution(target="foo", strategy="error", error_message="Network Fail")
+    with pytest.raises(DorsalError, match="Network Fail"):
+        install_model("foo")
+
+
+@patch("dorsal.api.model.prepare_model_target")
+@patch("dorsal.api.model.uninstall_model_target")
+def test_uninstall_model_wrapper(mock_uninstall_target, mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(target="foo/bar", strategy="registry_id")
+    mock_uninstall_target.return_value = "dorsal-bar"
+    assert uninstall_model("foo/bar") == "dorsal-bar"
+
+    mock_prepare.return_value = ModelTargetResolution(target="BuiltIn", strategy="pipeline")
+    with pytest.raises(DorsalError, match="Use 'dorsal config pipeline remove'"):
+        uninstall_model("BuiltIn")
+
+
 def test_run_or_install_model_happy_path_existing_pipeline(
-    mock_resolve_target,
-    mock_is_package_installed,
+    mock_prepare_model_target,
     mock_get_model_pipeline,
     mock_resolve_pipeline_step_models,
     mock_run_model,
     mock_install_model_target,
 ):
-    """Test running a model that is installed and exists in the active pipeline."""
-    target = "dorsal-whisper"
-    file_path = "/tmp/audio.mp3"
-    package_name = "dorsal-whisper"
-
-    mock_resolve_target.return_value = ("package_name", package_name)
-    mock_is_package_installed.return_value = True
+    target = "WhisperModel"
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="pipeline", package_name="dorsal-whisper", is_installed=True
+    )
 
     existing_step = ModelRunnerPipelineStep(
         annotation_model=CallableImportPath(module="dorsal_whisper", name="WhisperModel"),
         schema_id="audio/transcription",
-        package_name=package_name,
+        package_name="dorsal-whisper",
     )
     mock_get_model_pipeline.return_value = [existing_step]
 
@@ -107,52 +176,36 @@ def test_run_or_install_model_happy_path_existing_pipeline(
     mock_validator = MagicMock()
     mock_resolve_pipeline_step_models.return_value = (mock_annotator, mock_validator)
 
-    run_or_install_model(target, file_path)
+    run_or_install_model(target, "/tmp/audio.mp3")
 
     mock_install_model_target.assert_not_called()
-
-    mock_run_model.assert_called_once_with(
-        annotation_model=mock_annotator,
-        file_path=file_path,
-        schema_id=existing_step.schema_id,
-        schema_version=existing_step.schema_version,
-        validation_model=mock_validator,
-        dependencies=existing_step.dependencies,
-        options=existing_step.options,
-        ignore_linter_errors=existing_step.ignore_linter_errors,
-        progress_callback=None,
-    )
+    mock_run_model.assert_called_once()
 
 
 def test_run_or_install_model_auto_install_success(
-    mock_resolve_target,
-    mock_is_package_installed,
+    mock_prepare_model_target,
     mock_install_model_target,
-    mock_get_model_pipeline,
     mock_entry_points,
     mock_resources_files,
     mock_resolve_pipeline_step_models,
     mock_run_model,
 ):
-    """Test auto-installing a missing model, then constructing its step from metadata."""
     target = "dorsalhub/whisper"
-    file_path = "/tmp/audio.wav"
     package_name = "dorsal-whisper"
-    module_name = "dorsal_whisper"
 
-    mock_resolve_target.return_value = ("registry_id", package_name)
-    mock_is_package_installed.side_effect = [False, True]
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="registry_id", package_name=package_name, is_installed=False
+    )
 
-    mock_get_model_pipeline.return_value = []
+    mock_install_model_target.return_value = package_name
 
     mock_ep = MagicMock()
     mock_ep.dist.name = package_name
-    mock_ep.module = module_name
+    mock_ep.module = "dorsal_whisper"
     mock_entry_points.return_value = [mock_ep]
 
     mock_resource_path = MagicMock()
     mock_resource_path.is_file.return_value = True
-
     mock_resource_path.read_text.return_value = """
         model_class = "WhisperTranscriber"
         schema_id = "audio/transcription"
@@ -160,36 +213,25 @@ def test_run_or_install_model_auto_install_success(
     """
     mock_resources_files.return_value.__truediv__.return_value = mock_resource_path
 
-    run_or_install_model(target, file_path)
+    run_or_install_model(target, "file.wav")
 
     mock_install_model_target.assert_called_once_with(target)
-
-    call_args = mock_resolve_pipeline_step_models.call_args
-    assert call_args is not None
-    step_arg = call_args.args[0]
-
-    assert isinstance(step_arg, ModelRunnerPipelineStep)
-    assert step_arg.annotation_model.name == "WhisperTranscriber"
-    assert step_arg.schema_id == "audio/transcription"
-    assert step_arg.package_name == package_name
-
     mock_run_model.assert_called_once()
 
 
 def test_run_or_install_model_runtime_options(
-    mock_resolve_target,
-    mock_is_package_installed,
+    mock_prepare_model_target,
     mock_get_model_pipeline,
     mock_resolve_pipeline_step_models,
     mock_run_model,
 ):
-    """Test applying runtime options and linter flags."""
-    target = "dorsal-ocr"
-    mock_resolve_target.return_value = ("package_name", "dorsal-ocr")
-    mock_is_package_installed.return_value = True
+    target = "MyOCR"
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="pipeline", package_name="dorsal-ocr", is_installed=True
+    )
 
     base_step = ModelRunnerPipelineStep(
-        annotation_model=CallableImportPath(module="m", name="c"),
+        annotation_model=CallableImportPath(module="m", name="MyOCR"),
         schema_id="valid/schema-id",
         options={"lang": "en"},
         package_name="dorsal-ocr",
@@ -199,54 +241,43 @@ def test_run_or_install_model_runtime_options(
     run_or_install_model(target, "doc.pdf", options={"lang": "fr", "fast": True}, ignore_linter_errors=True)
 
     call_args = mock_run_model.call_args
-
     assert call_args.kwargs["options"] == {"lang": "fr", "fast": True}
     assert call_args.kwargs["ignore_linter_errors"] is True
 
 
 def test_annotator_execution_failure_propagates(
-    mock_resolve_target,
-    mock_is_package_installed,
-    mock_get_model_pipeline,
-    mock_resolve_pipeline_step_models,
-    mock_run_model,
+    mock_prepare_model_target, mock_get_model_pipeline, mock_resolve_pipeline_step_models, mock_run_model
 ):
-    """Test that exceptions raised during annotation are propagated."""
-    mock_resolve_target.return_value = ("package_name", "dorsal-fail")
-    mock_is_package_installed.return_value = True
-
+    target = "FailModel"
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="pipeline", package_name="dorsal-fail", is_installed=True
+    )
     step = ModelRunnerPipelineStep(
-        annotation_model=CallableImportPath(module="m", name="c"),
-        schema_id="valid/schema-id",
-        package_name="dorsal-fail",
+        annotation_model=CallableImportPath(module="m", name="FailModel"), schema_id="valid/schema-id"
     )
     mock_get_model_pipeline.return_value = [step]
-
     mock_run_model.side_effect = ValueError("Processing failed")
 
     with pytest.raises(ValueError, match="Processing failed"):
-        run_or_install_model("dorsal-fail", "f.txt")
+        run_or_install_model(target, "f.txt")
 
 
-def test_run_or_install_model_auto_install_failure(
-    mock_resolve_target, mock_is_package_installed, mock_install_model_target
-):
+def test_run_or_install_model_auto_install_failure(mock_prepare_model_target, mock_install_model_target):
     target = "owner/broken-repo"
-    mock_resolve_target.return_value = ("registry_id", "dorsal-broken")
-    mock_is_package_installed.return_value = False
-    mock_install_model_target.side_effect = Exception("Network error")
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="registry_id", package_name="dorsal-broken", is_installed=False
+    )
+    mock_install_model_target.side_effect = DorsalError("Network error")
 
-    with pytest.raises(DorsalError, match="Failed to auto-install model"):
+    with pytest.raises(DorsalError, match="Network error"):
         run_or_install_model(target, "file.txt")
 
 
-def test_construct_step_missing_entry_point(
-    mock_resolve_target, mock_is_package_installed, mock_get_model_pipeline, mock_entry_points
-):
+def test_construct_step_missing_entry_point(mock_prepare_model_target, mock_entry_points):
     target = "dorsal-ghost"
-    mock_resolve_target.return_value = ("package_name", "dorsal-ghost")
-    mock_is_package_installed.return_value = True
-    mock_get_model_pipeline.return_value = []
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target=target, strategy="package", package_name="dorsal-ghost", is_installed=True
+    )
 
     mock_ep = MagicMock()
     mock_ep.dist.name = "other-package"
@@ -256,13 +287,10 @@ def test_construct_step_missing_entry_point(
         run_or_install_model(target, "f.txt")
 
 
-def test_load_package_config_missing_file(
-    mock_resolve_target, mock_is_package_installed, mock_get_model_pipeline, mock_entry_points, mock_resources_files
-):
-    mock_resolve_target.return_value = ("package_name", "dorsal-pkg")
-    mock_is_package_installed.return_value = True
-    mock_get_model_pipeline.return_value = []
-
+def test_load_package_config_missing_file(mock_prepare_model_target, mock_entry_points, mock_resources_files):
+    mock_prepare_model_target.return_value = ModelTargetResolution(
+        target="dorsal-pkg", strategy="package", package_name="dorsal-pkg", is_installed=True
+    )
     mock_ep = MagicMock()
     mock_ep.dist.name = "dorsal-pkg"
     mock_ep.module = "dorsal_pkg"
@@ -277,14 +305,12 @@ def test_load_package_config_missing_file(
 
 
 def test_build_pipeline_step_missing_schema_id():
-    """Test that a missing schema_id raises a DorsalConfigError."""
     config = {"model_class": "MyModel"}
     with pytest.raises(DorsalConfigError, match="missing required field 'schema_id'"):
         _build_pipeline_step(config, "my_module", "my_pkg")
 
 
 def test_build_pipeline_step_options_parsing():
-    """Test the parsing of different dictionary structures in raw_options."""
     config = {
         "model_class": "MyModel",
         "schema_id": "test/schema",
@@ -297,47 +323,35 @@ def test_build_pipeline_step_options_parsing():
     step = _build_pipeline_step(config, "my_module", "my_pkg")
     assert step.schema_id == "test/schema"
     assert step.annotation_model.name == "MyModel"
+    assert step.options == {"flat_val": "value", "dict_with_default": 42, "dict_no_default": {"help": "just help text"}}
 
 
-@patch("dorsal.api.model.ModelRunnerPipelineStep")
-def test_build_pipeline_step_exception(mock_step_class):
-    """Test that construction exceptions (e.g. ValidationError) are wrapped in DorsalError."""
-    mock_step_class.side_effect = ValueError("Pydantic validation failed")
-    config = {"model_class": "MyModel", "schema_id": "test/schema"}
-
-    with pytest.raises(DorsalError, match="Failed to construct pipeline step for 'my_pkg'"):
-        _build_pipeline_step(config, "my_module", "my_pkg")
-
-
-@patch("dorsal.api.model.resolve_target")
-def test_get_model_help_resolve_error(mock_resolve):
-    """Test get_model_help handles resolution errors correctly."""
-    mock_resolve.side_effect = DorsalError("Target not found")
-
+@patch("dorsal.api.model.prepare_model_target")
+def test_get_model_help_resolve_error(mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(
+        target="bad-target", strategy="error", error_message="Target not found"
+    )
     res = get_model_help("bad-target")
     assert res["status"] == "error"
     assert res["error"] == "Target not found"
 
 
-@patch("dorsal.api.model.resolve_target")
-@patch("dorsal.api.model.is_package_installed")
-def test_get_model_help_not_installed(mock_installed, mock_resolve):
-    """Test get_model_help when the package is resolved but not installed."""
-    mock_resolve.return_value = ("package_name", "my-pkg")
-    mock_installed.return_value = False
-
+@patch("dorsal.api.model.prepare_model_target")
+def test_get_model_help_not_installed(mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(
+        target="my-pkg", strategy="registry_id", package_name="my-pkg", is_installed=False
+    )
     res = get_model_help("my-pkg")
     assert res["status"] == "not_installed"
     assert res["package_name"] == "my-pkg"
 
 
-@patch("dorsal.api.model.resolve_target")
-@patch("dorsal.api.model.is_package_installed")
+@patch("dorsal.api.model.prepare_model_target")
 @patch("dorsal.api.model._resolve_module_from_package")
-def test_get_model_help_config_error(mock_mod, mock_installed, mock_resolve):
-    """Test get_model_help when the configuration file fails to load."""
-    mock_resolve.return_value = ("package_name", "my-pkg")
-    mock_installed.return_value = True
+def test_get_model_help_config_error(mock_mod, mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(
+        target="my-pkg", strategy="registry_id", package_name="my-pkg", is_installed=True
+    )
     mock_mod.side_effect = DorsalConfigError("Missing module")
 
     res = get_model_help("my-pkg")
@@ -345,14 +359,13 @@ def test_get_model_help_config_error(mock_mod, mock_installed, mock_resolve):
     assert "Missing module" in res["error"]
 
 
-@patch("dorsal.api.model.resolve_target")
-@patch("dorsal.api.model.is_package_installed")
+@patch("dorsal.api.model.prepare_model_target")
 @patch("dorsal.api.model._resolve_module_from_package")
 @patch("dorsal.api.model._load_package_config")
-def test_get_model_help_success(mock_load, mock_mod, mock_installed, mock_resolve):
-    """Test get_model_help properly normalizes flat vs nested configuration dictionaries."""
-    mock_resolve.return_value = ("package_name", "my-pkg")
-    mock_installed.return_value = True
+def test_get_model_help_success(mock_load, mock_mod, mock_prepare):
+    mock_prepare.return_value = ModelTargetResolution(
+        target="my-pkg", strategy="registry_id", package_name="my-pkg", is_installed=True
+    )
     mock_mod.return_value = "my_module"
 
     mock_load.return_value = {
@@ -365,10 +378,7 @@ def test_get_model_help_success(mock_load, mock_mod, mock_installed, mock_resolv
     }
 
     res = get_model_help("my-pkg")
-
     assert res["status"] == "success"
-    assert res["options"]["flat_option"]["default"] == 10
-    assert res["options"]["dict_option"]["default"] == 20
-    assert res["options"]["dict_option"]["help"] == "a number"
-    assert res["options"]["dict_no_default"]["default"] == ""
-    assert res["options"]["dict_no_default"]["help"] == "no default provided"
+    options = res["options"]
+    assert options["flat_option"]["default"] == 10
+    assert options["dict_no_default"]["default"] is None

--- a/tests/cli/adapter_app/test_parse_cmd.py
+++ b/tests/cli/adapter_app/test_parse_cmd.py
@@ -125,8 +125,8 @@ def test_parse_cmd_with_options(mock_parse_deps, tmp_path, monkeypatch):
     assert result.exit_code == 0
 
     kwargs = mock_parse_deps["parse_api"].call_args.kwargs
-    assert kwargs["strict"] is True
-    assert kwargs["chunk"] == 5
+    assert kwargs["strict"] == "true"
+    assert kwargs["chunk"] == "5"
 
 
 def test_parse_cmd_no_save_flag(mock_parse_deps, tmp_path, monkeypatch):

--- a/tests/cli/model_app/test_checks.py
+++ b/tests/cli/model_app/test_checks.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+import sys
 import pytest
 import typer
 from unittest.mock import MagicMock
@@ -22,7 +22,7 @@ from rich.panel import Panel
 
 from dorsal.cli.model_app.checks import check_and_confirm_model_install
 from dorsal.cli.themes.palettes import DEFAULT_PALETTE
-from dorsal.common.exceptions import NotFoundError
+from dorsal.api.model import ModelTargetResolution, ModelMetadata
 
 DUMMY_UI_CONTEXT = {"palette": DEFAULT_PALETTE, "icons": {}, "borders": ROUNDED}
 
@@ -31,68 +31,70 @@ DUMMY_UI_CONTEXT = {"palette": DEFAULT_PALETTE, "icons": {}, "borders": ROUNDED}
 def mock_checks_deps(mocker, mock_rich_console):
     """
     Mocks backend dependencies for the model installation checks.
-    Targeting patches locally within the module to prevent network leakage.
     """
     mocker.patch("dorsal.common.cli.get_rich_console", return_value=mock_rich_console)
     mocker.patch("dorsal.common.cli.get_error_console", return_value=mock_rich_console)
 
-    mock_get_client = mocker.patch("dorsal.session.get_shared_dorsal_client")
-    mock_client_instance = mock_get_client.return_value
-
-    mock_reg_data = MagicMock()
-    mock_reg_data.namespace = "dorsal"
-    mock_reg_data.name = "gpt-neo"
-    mock_reg_data.is_official = True
-    mock_reg_data.is_verified = True
-    mock_reg_data.description = "A powerful mocked model."
-    mock_reg_data.install_url = "git+https://github.com/dorsal/gpt-neo.git"
-    mock_reg_data.created_at = datetime.datetime.now()
-
-    mock_client_instance.get_registry_model.return_value = mock_reg_data
-
-    mock_is_registry_id = mocker.patch("dorsal.registry.validators.is_registry_id", return_value=True)
-
     mock_shutil_which = mocker.patch("dorsal.cli.model_app.checks.shutil.which", return_value="/usr/bin/git")
-
     mock_confirm = mocker.patch("dorsal.cli.model_app.checks.Confirm.ask", return_value=True)
 
     return {
-        "client": mock_client_instance,
-        "reg_data": mock_reg_data,
-        "is_registry_id": mock_is_registry_id,
         "shutil_which": mock_shutil_which,
         "confirm": mock_confirm,
     }
 
 
 def test_check_install_verified_registry_model(mock_rich_console, mock_checks_deps):
-    """Tests check logic for a verified model from the registry."""
-    check_and_confirm_model_install("dorsal/gpt-neo", DUMMY_UI_CONTEXT)
+    """Tests that verified models silently bypass the security prompt."""
+    res = ModelTargetResolution(
+        target="dorsal/gpt-neo",
+        strategy="registry_id",
+        metadata=ModelMetadata(is_official=True, is_verified=True, description="A powerful mocked model."),
+    )
 
-    mock_checks_deps["client"].get_registry_model.assert_called_once_with("dorsal/gpt-neo")
+    check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
 
-    assert mock_rich_console.print.called
-    panel = mock_rich_console.print.call_args.args[0]
-    assert "Verified" in panel.renderable
-    assert "gpt-neo" in panel.renderable
+    assert not mock_rich_console.print.called
 
 
 def test_check_install_unverified_warning(mock_rich_console, mock_checks_deps):
     """Tests that unverified models trigger the Safety Warning."""
-    mock_checks_deps["reg_data"].is_official = False
-    mock_checks_deps["reg_data"].is_verified = False
+    res = ModelTargetResolution(
+        target="user/experimental-model",
+        strategy="registry_id",
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
 
-    check_and_confirm_model_install("user/experimental-model", DUMMY_UI_CONTEXT)
+    check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
 
     panel = mock_rich_console.print.call_args.args[0]
     assert "Unverified" in panel.renderable
 
 
+def test_check_install_local_path_warning(mock_rich_console, mock_checks_deps):
+    """Tests that local directories always trigger the Safety Warning."""
+    res = ModelTargetResolution(
+        target="./my-local-model",
+        strategy="local_path",
+    )
+
+    check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
+
+    panel = mock_rich_console.print.call_args.args[0]
+    assert "unverified source" in panel.renderable
+    assert "Local Path" in panel.renderable
+
+
 def test_check_install_skip_via_flags(mock_rich_console, mock_checks_deps):
     """Tests that 'force' or 'yes' flags bypass checks entirely."""
-    check_and_confirm_model_install("dorsal/gpt-neo", DEFAULT_PALETTE, yes=True)
+    res = ModelTargetResolution(
+        target="user/sketchy-model",
+        strategy="registry_id",
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
 
-    mock_checks_deps["client"].get_registry_model.assert_not_called()
+    check_and_confirm_model_install(res, DUMMY_UI_CONTEXT, yes=True)
+
     assert not mock_rich_console.print.called
 
 
@@ -100,8 +102,16 @@ def test_check_install_missing_git_dependency(mock_rich_console, mock_checks_dep
     """Tests handling of models requiring Git when Git is missing."""
     mock_checks_deps["shutil_which"].return_value = None
 
+    res = ModelTargetResolution(
+        target="dorsal/gpt-neo",
+        strategy="registry_id",
+        metadata=ModelMetadata(
+            is_official=False, is_verified=False, source_url="https://github.com/dorsal/gpt-neo.git"
+        ),
+    )
+
     with pytest.raises(typer.Exit):
-        check_and_confirm_model_install("dorsal/gpt-neo", DUMMY_UI_CONTEXT)
+        check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
 
     panel_calls = [c for c in mock_rich_console.print.call_args_list if isinstance(c.args[0], Panel)]
     assert len(panel_calls) > 0, "Missing System Dependency Panel was never printed"
@@ -111,22 +121,13 @@ def test_check_install_missing_git_dependency(mock_rich_console, mock_checks_dep
     assert "requires Git to install" in str(panel.renderable)
 
 
-def test_check_install_registry_not_found(mock_rich_console, mock_checks_deps):
-    """Tests 404 error handling from the registry."""
-    mock_checks_deps["client"].get_registry_model.side_effect = NotFoundError("404 Not Found")
-
-    with pytest.raises(typer.Exit):
-        check_and_confirm_model_install("dorsal/missing", DUMMY_UI_CONTEXT)
-
-    assert "Model 'dorsal/missing' not found in registry" in str(mock_rich_console.print.call_args.args[0])
-
-
 def test_check_install_user_cancels(mock_rich_console, mock_checks_deps):
     """Tests that the user can decline the confirmation prompt."""
     mock_checks_deps["confirm"].return_value = False
+    res = ModelTargetResolution(target="./sketchy", strategy="local_path")
 
     with pytest.raises(typer.Exit):
-        check_and_confirm_model_install("dorsal/gpt-neo", DUMMY_UI_CONTEXT)
+        check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
 
     assert "Cancelled" in str(mock_rich_console.print.call_args.args[0])
 
@@ -134,8 +135,9 @@ def test_check_install_user_cancels(mock_rich_console, mock_checks_deps):
 def test_check_install_pipx_note(mock_rich_console, mock_checks_deps, mocker):
     """Tests that a note is displayed when running in a pipx environment."""
     mocker.patch("sys.prefix", "/home/user/.local/pipx/venvs/dorsal")
+    res = ModelTargetResolution(target="./my-model", strategy="local_path")
 
-    check_and_confirm_model_install("dorsal/gpt-neo", DUMMY_UI_CONTEXT)
+    check_and_confirm_model_install(res, DUMMY_UI_CONTEXT)
 
     printed_text = str(mock_rich_console.print.call_args_list[0].args[0])
     assert "running inside a pipx environment" in printed_text

--- a/tests/cli/model_app/test_init_model.py
+++ b/tests/cli/model_app/test_init_model.py
@@ -18,11 +18,9 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-
 from dorsal.cli.model_app.init_model_cmd import init_model
 from dorsal.cli.themes.palettes import DEFAULT_PALETTE
 from dorsal.common.exceptions import DorsalError
-
 
 cli_app = typer.Typer()
 
@@ -42,10 +40,10 @@ def mock_init_cmd(mocker, mock_rich_console):
     """
     Mocks backend dependencies for the `init_model` command.
     """
-
     mocker.patch("dorsal.common.cli.get_rich_console", return_value=mock_rich_console)
 
-    mock_create_project = mocker.patch("dorsal.registry.initialize.create_new_annotation_model_project")
+    # FIX: Patch the true source of the API wrapper, since it is locally imported inside the command.
+    mock_create_project = mocker.patch("dorsal.api.model.init_model_project")
 
     mock_result = MagicMock()
     mock_result.clean_name = "receipt-scanner"

--- a/tests/cli/model_app/test_install_model.py
+++ b/tests/cli/model_app/test_install_model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 from unittest.mock import MagicMock
 import pytest
 
@@ -22,8 +21,8 @@ from rich.box import ROUNDED
 
 from dorsal.cli.model_app.install_model_cmd import install_model
 from dorsal.cli.themes.palettes import DEFAULT_PALETTE
-from dorsal.common.exceptions import DorsalError, NotFoundError
-
+from dorsal.common.exceptions import DorsalError
+from dorsal.api.model import ModelTargetResolution, ModelMetadata
 
 cli_app = typer.Typer()
 
@@ -48,38 +47,25 @@ def mock_install_cmd(mocker, mock_rich_console):
     mocker.patch("dorsal.common.cli.get_rich_console", return_value=mock_rich_console)
     mocker.patch("dorsal.common.cli.get_error_console", return_value=mock_rich_console)
 
-    mock_installer = mocker.patch("dorsal.registry.installer.install_model_target")
-    mock_installer.return_value = "dorsal-model-package"
+    mock_prepare = mocker.patch("dorsal.api.model.prepare_model_target")
 
-    mock_get_client = mocker.patch("dorsal.session.get_shared_dorsal_client")
-    mock_client_instance = mock_get_client.return_value
+    mock_resolution = ModelTargetResolution(
+        target="dorsal/gpt-neo",
+        strategy="registry_id",
+        metadata=ModelMetadata(is_official=True, is_verified=True, description="Mocked model."),
+    )
+    mock_prepare.return_value = mock_resolution
 
-    mock_reg_data = MagicMock()
-    mock_reg_data.namespace = "dorsal"
-    mock_reg_data.name = "gpt-neo"
-    mock_reg_data.is_official = True
-    mock_reg_data.is_verified = True
-    mock_reg_data.description = "A powerful mocked model."
-    mock_reg_data.install_url = "git+https://github.com/dorsal/gpt-neo.git"
-    mock_reg_data.created_at = datetime.datetime.now()
-    mock_reg_data.package_name = "dorsal-gpt-neo"
+    mock_installer = mocker.patch("dorsal.api.model.install_model")
+    mock_installer.return_value = "dorsal-gpt-neo"
 
-    mock_client_instance.get_registry_model.return_value = mock_reg_data
-
-    mock_is_registry_id = mocker.patch("dorsal.registry.validators.is_registry_id", return_value=True)
-
-    mock_shutil_which = mocker.patch("dorsal.cli.model_app.checks.shutil.which", return_value="/usr/bin/git")
-
-    mock_confirm = mocker.patch("rich.prompt.Confirm.ask", return_value=True)
+    mock_check = mocker.patch("dorsal.cli.model_app.checks.check_and_confirm_model_install")
 
     return {
+        "prepare": mock_prepare,
         "installer": mock_installer,
-        "get_client": mock_get_client,
-        "client": mock_client_instance,
-        "reg_data": mock_reg_data,
-        "is_registry_id": mock_is_registry_id,
-        "shutil_which": mock_shutil_which,
-        "confirm": mock_confirm,
+        "check": mock_check,
+        "resolution": mock_resolution,
     }
 
 
@@ -89,10 +75,8 @@ def test_install_model_basic_success(mock_rich_console, mock_install_cmd):
 
     assert result.exit_code == 0, result.output
 
-    mock_install_cmd["client"].get_registry_model.assert_called_once_with("dorsal/gpt-neo")
-
-    mock_install_cmd["confirm"].assert_called_once()
-
+    mock_install_cmd["prepare"].assert_called_once_with("dorsal/gpt-neo")
+    mock_install_cmd["check"].assert_called_once()
     mock_install_cmd["installer"].assert_called_once_with("dorsal/gpt-neo", scope="project", force_reinstall=False)
 
     assert mock_rich_console.print.called
@@ -101,15 +85,11 @@ def test_install_model_basic_success(mock_rich_console, mock_install_cmd):
 
 def test_install_model_interactive_decline(mock_rich_console, mock_install_cmd):
     """Tests that declining the confirmation prompt aborts the installation."""
-    mock_install_cmd["confirm"].return_value = False
+    mock_install_cmd["check"].side_effect = typer.Exit(0)
 
     result = runner.invoke(cli_app, ["install", "dorsal/gpt-neo"])
 
-    assert result.exit_code == 0, result.output
-
-    assert mock_rich_console.print.called
-    assert "Cancelled" in str(mock_rich_console.print.call_args_list[-1].args[0])
-
+    assert result.exit_code == 0
     mock_install_cmd["installer"].assert_not_called()
 
 
@@ -118,7 +98,8 @@ def test_install_model_yes_flag(mock_install_cmd):
     result = runner.invoke(cli_app, ["install", "dorsal/gpt-neo", "--yes"])
 
     assert result.exit_code == 0, result.output
-    mock_install_cmd["confirm"].assert_not_called()
+    call_args = mock_install_cmd["check"].call_args
+    assert call_args.kwargs.get("yes") is True
     mock_install_cmd["installer"].assert_called_once()
 
 
@@ -131,52 +112,28 @@ def test_install_model_global_flag(mock_install_cmd):
 
 
 def test_install_model_force_flag(mock_install_cmd):
-    """Tests that --force passes force_reinstall=True and skips confirmation."""
-    result = runner.invoke(cli_app, ["install", "dorsal/gpt-neo", "--force"])
+    """Tests that --force-reinstall passes force_reinstall=True and skips confirmation."""
+    result = runner.invoke(cli_app, ["install", "dorsal/gpt-neo", "--force-reinstall"])
 
     assert result.exit_code == 0, result.output
-    mock_install_cmd["confirm"].assert_not_called()
+    call_args = mock_install_cmd["check"].call_args
+    assert call_args.kwargs.get("force") is True
     mock_install_cmd["installer"].assert_called_once_with("dorsal/gpt-neo", scope="project", force_reinstall=True)
-
-
-def test_install_model_missing_git(mock_rich_console, mock_install_cmd):
-    """Tests that missing git dependency causes an error exit."""
-
-    mock_install_cmd["shutil_which"].return_value = None
-
-    result = runner.invoke(cli_app, ["install", "dorsal/gpt-neo"])
-
-    assert result.exit_code != 0
-
-    assert mock_rich_console.print.called
-    output_str = str(mock_rich_console.print.call_args_list[0].args[0].renderable)
-    assert "requires Git to install" in output_str
-    assert "Missing System Dependency" in str(mock_rich_console.print.call_args_list[0].args[0].title)
 
 
 def test_install_model_registry_not_found(mock_rich_console, mock_install_cmd):
     """Tests handling of a 404 from the registry."""
-    mock_install_cmd["client"].get_registry_model.side_effect = NotFoundError("Model not found")
+    mock_install_cmd["prepare"].return_value = ModelTargetResolution(
+        target="dorsal/missing-model",
+        strategy="error",
+        error_message="Model 'dorsal/missing-model' not found in registry.",
+    )
 
     result = runner.invoke(cli_app, ["install", "dorsal/missing-model"])
 
     assert result.exit_code != 0
     assert mock_rich_console.print.called
-    assert "Error: Model 'dorsal/missing-model' not found in registry" in str(mock_rich_console.print.call_args[0][0])
-
-
-def test_install_model_unverified_warning(mock_rich_console, mock_install_cmd):
-    """Tests that unverified models trigger a safety warning in the panel."""
-
-    mock_install_cmd["reg_data"].is_official = False
-    mock_install_cmd["reg_data"].is_verified = False
-
-    runner.invoke(cli_app, ["install", "user/sketchy-model"])
-
-    assert mock_rich_console.print.called
-
-    panel = mock_rich_console.print.call_args_list[0].args[0]
-    assert "Unverified" in str(panel.renderable)
+    assert "not found in registry" in str(mock_rich_console.print.call_args[0][0])
 
 
 def test_install_model_install_failure(mock_rich_console, mock_install_cmd):

--- a/tests/cli/model_app/test_run_model.py
+++ b/tests/cli/model_app/test_run_model.py
@@ -27,7 +27,7 @@ from dorsal.cli.themes.palettes import DEFAULT_PALETTE
 from dorsal.common.exceptions import DorsalError, AuthError
 from dorsal.file.configs.model_runner import RunModelResult
 from dorsal.common.model import AnnotationModelSource
-
+from dorsal.api.model import ModelTargetResolution, ModelMetadata
 
 cli_app = typer.Typer()
 
@@ -64,16 +64,20 @@ def mock_run_deps(mocker, mock_rich_console):
     default_result = RunModelResult(
         name="MockModel",
         source=AnnotationModelSource(type="Model", id="mock/model", version="1.0.0"),
-        records=[{"summary": "Processed successfully"}],  # <--- CHANGED HERE
+        records=[{"summary": "Processed successfully"}],
         schema_id="mock/schema",
     )
     mock_runner.return_value = [default_result]
 
-    mock_resolve = mocker.patch("dorsal.registry.resolution.resolve_target")
-    mock_resolve.return_value = ("registry", "dorsal-receipt-scanner")
-
-    mock_is_installed = mocker.patch("dorsal.registry.resolution.is_package_installed")
-    mock_is_installed.return_value = True
+    mock_prepare = mocker.patch("dorsal.api.model.prepare_model_target")
+    default_resolution = ModelTargetResolution(
+        target="dorsal/scanner",
+        strategy="registry_id",
+        package_name="dorsal-scanner",
+        is_installed=True,
+        metadata=ModelMetadata(is_official=True, is_verified=True),
+    )
+    mock_prepare.return_value = default_resolution
 
     mock_check_safety = mocker.patch("dorsal.cli.model_app.checks.check_and_confirm_model_install")
     mock_create_panel = mocker.patch("dorsal.cli.views.model.create_model_result_panel")
@@ -81,8 +85,8 @@ def mock_run_deps(mocker, mock_rich_console):
     return {
         "run_logic": mock_runner,
         "result": default_result,
-        "resolve": mock_resolve,
-        "is_installed": mock_is_installed,
+        "prepare": mock_prepare,
+        "resolution": default_resolution,
         "check_safety": mock_check_safety,
         "create_panel": mock_create_panel,
         "error_console": mock_error_console,
@@ -123,7 +127,7 @@ def test_run_model_with_options_parsing(mock_run_deps, tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 0
-    expected_options = {"engine": "ocr", "dpi": 300}
+    expected_options = {"engine": "ocr", "dpi": "300"}
     assert mock_run_deps["run_logic"].call_args.kwargs["options"] == expected_options
 
     printed_messages = [str(call.args[0]) for call in mock_run_deps["error_console"].print.call_args_list]
@@ -131,22 +135,36 @@ def test_run_model_with_options_parsing(mock_run_deps, tmp_path, monkeypatch):
 
 
 def test_run_model_triggers_safety_check_when_not_installed(mock_run_deps, tmp_path, monkeypatch):
-    """Tests that safety checks are triggered if the package isn't installed."""
-    mock_run_deps["is_installed"].return_value = False
+    """Tests that safety checks are triggered if the package isn't installed and is unverified."""
+
+    res = ModelTargetResolution(
+        target="user/scanner",
+        strategy="registry_id",
+        package_name="user-scanner",
+        is_installed=False,
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
+    mock_run_deps["prepare"].return_value = res
 
     monkeypatch.chdir(tmp_path)
     test_file = pathlib.Path("test.pdf")
     test_file.touch()
 
-    runner.invoke(cli_app, ["run", "dorsal/scanner", str(test_file)])
+    runner.invoke(cli_app, ["run", "user/scanner", str(test_file)])
 
-    # Update DEFAULT_PALETTE to DUMMY_UI_CONTEXT here:
-    mock_run_deps["check_safety"].assert_called_once_with("dorsal/scanner", DUMMY_UI_CONTEXT, yes=False)
+    mock_run_deps["check_safety"].assert_called_once_with(res, DUMMY_UI_CONTEXT, yes=False)
 
 
 def test_run_model_json_output(mock_rich_console, mock_run_deps, tmp_path, monkeypatch):
     """Tests --json mode, verifying raw output and skipped safety UI."""
-    mock_run_deps["is_installed"].return_value = False
+    res = ModelTargetResolution(
+        target="dorsal/scanner",
+        strategy="registry_id",
+        package_name="user-scanner",
+        is_installed=False,
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
+    mock_run_deps["prepare"].return_value = res
 
     monkeypatch.chdir(tmp_path)
     test_file = pathlib.Path("test.pdf")
@@ -338,7 +356,7 @@ def test_run_model_batch_processing(mock_rich_console, mock_run_deps, mocker, tm
     def mock_run_logic(*args, **kwargs):
         if "test_0.pdf" in kwargs.get("file_path", ""):
             raise Exception("Simulated inner error")
-        return mock_run_deps["result"]
+        return [mock_run_deps["result"]]
 
     mock_run_deps["run_logic"].side_effect = mock_run_logic
 
@@ -371,7 +389,7 @@ def test_run_model_progress_hook_coverage(mock_run_deps, tmp_path, monkeypatch):
         if cb:
             cb(10.0, 100.0)
             cb(50.0, 100.0, "Downloading model weights...")
-        return mock_run_deps["result"]
+        return [mock_run_deps["result"]]
 
     mock_run_deps["run_logic"].side_effect = mock_run_with_progress
 
@@ -467,7 +485,14 @@ def test_run_model_empty_directory(mock_run_deps, mocker, tmp_path, monkeypatch)
 
 def test_run_model_install_check_aborted(mock_run_deps, tmp_path, monkeypatch):
     """Covers the `except typer.Exit: raise` block when a user aborts the install prompt."""
-    mock_run_deps["is_installed"].return_value = False
+    res = ModelTargetResolution(
+        target="user/scanner",
+        strategy="registry_id",
+        package_name="user-scanner",
+        is_installed=False,
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
+    mock_run_deps["prepare"].return_value = res
     mock_run_deps["check_safety"].side_effect = typer.Exit(1)
 
     monkeypatch.chdir(tmp_path)
@@ -482,7 +507,14 @@ def test_run_model_install_check_aborted(mock_run_deps, tmp_path, monkeypatch):
 
 def test_run_model_install_check_exception_passed(mock_run_deps, tmp_path, monkeypatch):
     """Covers the `except Exception: pass` block if resolution or checking fails non-fatally."""
-    mock_run_deps["is_installed"].return_value = False
+    res = ModelTargetResolution(
+        target="user/scanner",
+        strategy="registry_id",
+        package_name="user-scanner",
+        is_installed=False,
+        metadata=ModelMetadata(is_official=False, is_verified=False),
+    )
+    mock_run_deps["prepare"].return_value = res
     mock_run_deps["check_safety"].side_effect = Exception("Random unexpected error")
 
     monkeypatch.chdir(tmp_path)
@@ -637,7 +669,6 @@ def test_run_model_auth_error_propagation(mock_run_deps, tmp_path, monkeypatch):
 
     result = runner.invoke(cli_app, ["run", "dorsal/scanner", str(test_file)])
 
-    # Typer catches unhandled explicit raises and stores them in result.exception
     assert isinstance(result.exception, AuthError)
 
 
@@ -693,11 +724,11 @@ def test_run_model_borders_none_padding(mock_run_deps, tmp_path, monkeypatch):
 
 def test_run_model_outer_typer_exit(mock_run_deps, mocker, tmp_path, monkeypatch):
     """Covers propagating typer.Exit from the outer execution loop."""
-    mocker.patch("rich.progress.Progress.__enter__", side_effect=typer.Exit(42))
+    mocker.patch("rich.progress.Progress.__enter__", side_effect=typer.Exit(9000))
 
     monkeypatch.chdir(tmp_path)
     test_file = pathlib.Path("test.pdf")
     test_file.touch()
 
     result = runner.invoke(cli_app, ["run", "dorsal/scanner", str(test_file)])
-    assert result.exit_code == 42
+    assert result.exit_code == 9000

--- a/tests/cli/model_app/test_uninstall_model.py
+++ b/tests/cli/model_app/test_uninstall_model.py
@@ -17,11 +17,10 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-
 from dorsal.cli.model_app.uninstall_model_cmd import uninstall_model
 from dorsal.cli.themes.palettes import DEFAULT_PALETTE
 from dorsal.common.exceptions import DorsalError
-
+from dorsal.api.model import ModelTargetResolution
 
 cli_app = typer.Typer()
 
@@ -41,15 +40,18 @@ def mock_uninstall_cmd(mocker, mock_rich_console):
     """
     Mocks backend dependencies for the `uninstall_model` command.
     """
-
     mocker.patch("dorsal.common.cli.get_rich_console", return_value=mock_rich_console)
 
-    mock_uninstaller = mocker.patch("dorsal.registry.uninstaller.uninstall_model_target")
+    mock_prepare = mocker.patch("dorsal.api.model.prepare_model_target")
+    mock_prepare.return_value = ModelTargetResolution(target="dorsal/gpt-neo", strategy="registry_id")
+
+    mock_uninstaller = mocker.patch("dorsal.api.model.uninstall_model")
     mock_uninstaller.return_value = "dorsal-gpt-neo"
 
     mock_confirm = mocker.patch("rich.prompt.Confirm.ask", return_value=True)
 
     return {
+        "prepare": mock_prepare,
         "uninstaller": mock_uninstaller,
         "confirm": mock_confirm,
     }
@@ -62,7 +64,6 @@ def test_uninstall_model_interactive_success(mock_rich_console, mock_uninstall_c
     assert result.exit_code == 0, result.output
 
     mock_uninstall_cmd["confirm"].assert_called_once()
-
     mock_uninstall_cmd["uninstaller"].assert_called_once_with("dorsal/gpt-neo", scope="project")
 
     assert mock_rich_console.print.called
@@ -127,3 +128,14 @@ def test_uninstall_model_unexpected_error(mock_rich_console, mock_uninstall_cmd)
     output_str = str(mock_rich_console.print.call_args.args[0])
     assert "Unexpected Error" in output_str
     assert "Permission denied" in output_str
+
+
+def test_uninstall_model_pipeline_error(mock_rich_console, mock_uninstall_cmd):
+    """Tests that the CLI blocks uninstalling a core pipeline model."""
+    mock_uninstall_cmd["prepare"].return_value = ModelTargetResolution(target="BuiltIn", strategy="pipeline")
+
+    result = runner.invoke(cli_app, ["uninstall", "BuiltIn", "--yes"])
+
+    assert result.exit_code != 0
+    output_str = str(mock_rich_console.print.call_args.args[0])
+    assert "built-in core model" in output_str

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -93,7 +93,7 @@ def test_parse_cli_options_malformed(mock_get_error_console):
 
     result = cli.parse_cli_options(options, palette)
 
-    assert result == {"valid": True}
+    assert result == {"valid": "true"}
     mock_console.print.assert_called_once()
     assert "Skipping malformed option 'invalid_no_equals'" in mock_console.print.call_args[0][0]
 
@@ -114,16 +114,16 @@ def test_parse_cli_options_basic_types():
     ]
 
     expected = {
-        "is_true": True,
-        "is_yes": True,
-        "is_false": False,
-        "is_no": False,
-        "is_null": None,
-        "is_none": None,
-        "integer": 42,
-        "floating": 3.14,
+        "is_true": "true",
+        "is_yes": "yes",
+        "is_false": "false",
+        "is_no": "no",
+        "is_null": "null",
+        "is_none": "none",
+        "integer": "42",
+        "floating": "3.14",
         "string": "hello world",
-        "mixed_case_bool": True,
+        "mixed_case_bool": "TrUe",
     }
 
     assert cli.parse_cli_options(options, {}) == expected
@@ -441,13 +441,11 @@ def test_render_model_help_panel_error(mock_ui_context):
 
 def test_render_model_help_panel_not_installed(mock_ui_context):
     """Test the panel rendering when a model is resolved but not installed."""
-    help_info = {"status": "not_installed", "target": "my-target", "package_name": "my-pkg"}
+    help_info = {"status": "not_installed", "target": "org/my-target", "package_name": "my-pkg"}
     panel = cli.render_model_help_panel(help_info, mock_ui_context)
 
     assert isinstance(panel, Panel)
     assert "my-pkg" in str(panel.renderable)
-    assert "dorsal model install my-target" in str(panel.renderable)
-    assert "Model: my-target" in str(panel.title)
 
 
 def test_render_model_help_panel_config_error(mock_ui_context):
@@ -472,27 +470,61 @@ def test_render_model_help_panel_success_no_options(mock_ui_context):
 
 
 def test_render_model_help_panel_success_with_options(mock_ui_context):
-    """Test the full table rendering for a model with a valid configuration and options."""
+    """Test the full table rendering, strictly verifying row contents and formatting."""
     from rich.table import Table
+    from rich.console import Group
 
     help_info = {
         "status": "success",
         "package_name": "my-pkg",
         "model_class": "MyClass",
         "options": {
-            "batch_size": {"default": 16, "help": "Batch size for inference"},
-            "language": {"help": "Target language"},
+            # Rule 1 & 2: Explicit type, has default
+            "batch_size": {"type": "int", "default": 16, "help": "Batch size for inference"},
+            # Rule 3: No default, missing type fallback
+            "language": {"type": "str", "default": None, "help": "Target language"},
+            # Edge case: Empty string default
+            "prefix": {"type": "str", "default": "", "help": "Prefix text"},
         },
     }
 
     panel = cli.render_model_help_panel(help_info, mock_ui_context)
 
-    assert isinstance(panel, Panel)
     assert isinstance(panel.renderable, Group)
-    assert "Model Options: MyClass" in str(panel.title)
-
     table = panel.renderable.renderables[0]
     assert isinstance(table, Table)
 
-    assert len(table.columns) == 3
+    assert len(table.columns) == 4
     assert table.columns[0].header == "Option"
+    assert table.columns[1].header == "Type"
+    assert table.columns[2].header == "Default"
+    assert table.columns[3].header == "Description"
+
+    options_col = list(table.columns[0].cells)
+    types_col = list(table.columns[1].cells)
+    defaults_col = list(table.columns[2].cells)
+
+    assert options_col == ["batch_size", "language", "prefix"]
+
+    assert types_col == ["Integer", "String", "String"]
+    assert defaults_col == ["16", "<unassigned>", '""']
+
+
+def test_render_model_help_panel_not_installed_registry(mock_ui_context):
+    """Test the panel rendering when a registry model is resolved but not installed."""
+    help_info = {"status": "not_installed", "target": "org/my-target", "package_name": "my-pkg"}
+    panel = cli.render_model_help_panel(help_info, mock_ui_context)
+
+    assert isinstance(panel, Panel)
+    assert "org/my-target" in str(panel.renderable)
+    assert "my-pkg" in str(panel.renderable)
+
+
+def test_render_model_help_panel_not_installed_local(mock_ui_context):
+    """Test the panel rendering when a local class name is provided but not installed."""
+    help_info = {"status": "not_installed", "target": "MyTarget", "package_name": "mytarget"}
+    panel = cli.render_model_help_panel(help_info, mock_ui_context)
+
+    assert isinstance(panel, Panel)
+    assert "MyTarget" in str(panel.renderable)
+    assert "organization/project" in str(panel.renderable)

--- a/tests/file/test_model_runner.py
+++ b/tests/file/test_model_runner.py
@@ -1308,3 +1308,122 @@ class TestModelRunnerChunkRescueAndMultiOutput:
         assert result[1].error is None
         assert result[0].records[0] == {"text": "chk1"}
         assert result[1].records[0] == {"text": "chk2"}
+
+
+class TestModelRunnerTypeCoercion:
+    """Tests for the new schema extraction and type coercion logic."""
+
+    def test_coerce_options_basic_types(self):
+        """Tests that string options are correctly coerced based on the expected schema."""
+        schema = {
+            "is_bool_1": "bool",
+            "is_bool_2": "boolean",
+            "is_int_1": "int",
+            "is_int_2": "integer",
+            "is_float_1": "float",
+            "is_float_2": "double",
+            "is_str": "str",
+        }
+
+        raw_options = {
+            "is_bool_1": "true",
+            "is_bool_2": "1",
+            "is_int_1": "42",
+            "is_int_2": "invalid_int_fallback",  # Should fall back to string safely
+            "is_float_1": "3.14",
+            "is_float_2": "invalid_float_fallback",
+            "is_str": "100",  # Should remain string
+            "undeclared": "passthrough",  # Not in schema, should pass through
+            "already_parsed_dict": {"complex": "data"},  # Non-strings should be left alone
+        }
+
+        coerced = ModelRunner._coerce_options(raw_options, schema)
+
+        assert coerced["is_bool_1"] is True
+        assert coerced["is_bool_2"] is True
+        assert coerced["is_int_1"] == 42
+        assert coerced["is_int_2"] == "invalid_int_fallback"
+        assert coerced["is_float_1"] == 3.14
+        assert coerced["is_float_2"] == "invalid_float_fallback"
+        assert coerced["is_str"] == "100"
+        assert coerced["undeclared"] == "passthrough"
+        assert coerced["already_parsed_dict"] == {"complex": "data"}
+
+    def test_get_schema_for_model_success(self, mocker):
+        """Tests that the schema is correctly extracted from a mocked model_config.toml."""
+
+        mock_file = MagicMock()
+        mock_file.is_file.return_value = True
+
+        import textwrap
+
+        mock_file.read_text.return_value = textwrap.dedent("""
+            [options]
+            explicit_int = {type = "int"}
+            inferred_bool = {default = true}
+            inferred_str = {default = "hello"}
+            missing_type_dict = {}
+            flat_str_fallback = "flat_string_value"
+        """).strip()
+
+        mock_dir = MagicMock()
+        mock_dir.__truediv__.return_value = mock_file
+
+        mocker.patch("importlib.resources.files", return_value=mock_dir)
+
+        schema = ModelRunner._get_schema_for_model(MockSuccessAnnotationModel)
+
+        assert schema["explicit_int"] == "int"
+        assert schema["inferred_bool"] == "bool"
+        assert schema["inferred_str"] == "str"
+        assert schema["missing_type_dict"] == "str"
+        assert schema["flat_str_fallback"] == "str"
+
+    def test_get_schema_for_model_no_file(self, mocker):
+        """Tests that an empty dictionary is returned if model_config.toml is missing."""
+        mock_file = MagicMock()
+        mock_file.is_file.return_value = False
+
+        mock_dir = MagicMock()
+        mock_dir.__truediv__.return_value = mock_file
+
+        mocker.patch("importlib.resources.files", return_value=mock_dir)
+
+        schema = ModelRunner._get_schema_for_model(MockSuccessAnnotationModel)
+        assert schema == {}
+
+    def test_run_single_model_coercion_integration(self, base_model_runner, mocker):
+        """Tests that run_single_model intercepts string options and passes coerced values to main()."""
+        mocker.patch.object(ModelRunner, "_get_schema_for_model", return_value={"threshold": "float"})
+
+        spy = mocker.spy(SingleOutputModel, "main")
+
+        base_model_runner.run_single_model(
+            annotation_model=SingleOutputModel,
+            validation_model=None,
+            file_path="/fake/path",
+            options={"threshold": "0.95", "passthrough": "123"},
+        )
+
+        spy.assert_called_once()
+        kwargs = spy.call_args.kwargs
+
+        assert kwargs["threshold"] == 0.95
+        assert kwargs["passthrough"] == "123"
+
+    def test_coerce_options_strict_fallback(self):
+        """Tests that fields falling back to 'str' are not accidentally cast to ints or bools."""
+        schema = {"batch_size": "str", "language": "str"}
+
+        raw_options = {
+            "batch_size": "8",
+            "language": "true",
+        }
+
+        coerced = ModelRunner._coerce_options(raw_options, schema)
+
+        assert coerced["batch_size"] == "8"
+        assert coerced["language"] == "true"
+
+        assert isinstance(coerced["batch_size"], str)
+        assert isinstance(coerced["language"], str)


### PR DESCRIPTION
* Decoupled CLI commands (`run`, `install`, `uninstall`, `init`) from `dorsal.registry`.
* Moved option parsing (`--opt`) out of the CLI. Values are now coerced by `ModelRunner` using the model's schema.
* Updated `dorsal model run <target> --help` to display option types and `<unassigned>` defaults.